### PR TITLE
Piapro links error + YouTube links

### DIFF
--- a/VocaDbModel/Service/Helpers/ArtistExternalUrlParser.cs
+++ b/VocaDbModel/Service/Helpers/ArtistExternalUrlParser.cs
@@ -29,7 +29,7 @@ namespace VocaDb.Model.Service.Helpers {
 		};
 
 		private static readonly string[] whitelistedUrls = {
-			"http://piapro.jp/"
+			"http://piapro.jp/", "https://piapro.jp/", "http://www.piapro.jp/", "https://www.piapro.jp/"
 		};
 
 		/// <summary>

--- a/VocaDbWeb/Content/Styles/ExtLinks.css
+++ b/VocaDbWeb/Content/Styles/ExtLinks.css
@@ -210,7 +210,9 @@ a.extLink[href^="http://chokuhan.nicovideo.jp/"] {
   background: url("/Content/ExtIcons/nicochokuhan.png") no-repeat left 50%;
 }
 a.extLink[href^="http://piapro.jp/"],
-a.extLink[href^="http://www.piapro.jp/"] {
+a.extLink[href^="http://www.piapro.jp/"],
+a.extLink[href^="https://piapro.jp/"],
+a.extLink[href^="https://www.piapro.jp/"] {
   background: url("/Content/ExtIcons/piapro.png") no-repeat left 50%;
 }
 a.extLink[href^="http://books.rakuten.co.jp/"] {
@@ -245,7 +247,8 @@ a.extLink[href^="http://www.youtube.com/"],
 a.extLink[href^="https://www.youtube.com/"],
 a.extLink[href^="http://youtube.com/"],
 a.extLink[href^="https://youtube.com/"],
-a.extLink[href^="http://youtu.be/"] {
+a.extLink[href^="http://youtu.be/"],
+a.extLink[href^="https://youtu.be/"] {
   background: url("/Content/youtube.png") no-repeat left 50%;
 }
 a.extLink[href^="http://vocaloid.wikia.com/wiki/"] {

--- a/VocaDbWeb/Content/Styles/ExtLinks.less
+++ b/VocaDbWeb/Content/Styles/ExtLinks.less
@@ -248,7 +248,7 @@ a.extLink[href^="http://chokuhan.nicovideo.jp/"] {
     .extLink(url("/Content/ExtIcons/nicochokuhan.png"));
 }
 
-a.extLink[href^="http://piapro.jp/"], a.extLink[href^="http://www.piapro.jp/"] {
+a.extLink[href^="http://piapro.jp/"], a.extLink[href^="http://www.piapro.jp/"], a.extLink[href^="https://piapro.jp/"], a.extLink[href^="https://www.piapro.jp/"] {
 	.extLink(url("/Content/ExtIcons/piapro.png"));
 }
 

--- a/VocaDbWeb/Content/Styles/ExtLinks.less
+++ b/VocaDbWeb/Content/Styles/ExtLinks.less
@@ -292,7 +292,8 @@ a.extLink[href^="http://www.youtube.com/"],
 a.extLink[href^="https://www.youtube.com/"], 
 a.extLink[href^="http://youtube.com/"],
 a.extLink[href^="https://youtube.com/"],
-a.extLink[href^="http://youtu.be/"] {
+a.extLink[href^="http://youtu.be/"],
+a.extLink[href^="https://youtu.be/"] {
 	.extLink(url("/Content/youtube.png"));
 }
 


### PR DESCRIPTION
As brought up in this discussion: https://vocadb.net/discussion/topics/157 There's been some issues with Piapro links, and I think that's because perhaps "https" was added. I added it with the piapro-https-links branch. I also added https://youtu.be/ for YouTube.
I don't know if I did everything necessary, though.