### PR TITLE
Fix garbled credit text

### DIFF
--- a/VocaDbWeb/Views/Shared/Partials/_Footer.cshtml
+++ b/VocaDbWeb/Views/Shared/Partials/_Footer.cshtml
@@ -1,4 +1,4 @@
-@*<span class="about-disclaimer">Background illustration by <a href="https://www.pixiv.net/member_illust.php?mode=medium&illust_id=39733249">火神レオ</a> | <a href="https://code.google.com/p/vocadb/">Other credits</a></span>*@
+﻿@*<span class="about-disclaimer">Background illustration by <a href="https://www.pixiv.net/member_illust.php?mode=medium&illust_id=39733249">火神レオ</a> | <a href="https://code.google.com/p/vocadb/">Other credits</a></span>*@
 <span class="about-disclaimer">
 	<a href="https://piapro.jp/t/nire">@string.Format(ViewRes._LayoutStrings.BackgroundCredit, "みゆ")</a>
 	|


### PR DESCRIPTION
The credit text "みゆ" in the footer is not displayed correctly due to the wrong encoding.