### PR TITLE
#542: ignore all markdown fields from KO binding

### DIFF
--- a/VocaDbWeb/App_Code/HtmlHelpers.cshtml
+++ b/VocaDbWeb/App_Code/HtmlHelpers.cshtml
@@ -1,4 +1,4 @@
-@inherits VocaDb.Web.Code.HelperPage
+﻿@inherits VocaDb.Web.Code.HelperPage
 @using System.Web.Mvc
 @using VocaDb.Web.Code
 @using VocaDb.Web.Helpers;
@@ -16,9 +16,15 @@
 	</div>
 }
 
-@* Transforms Markdown-formatted text into HTML. The input will be sanitized for any HTML tags first. *@
+@*  Transforms Markdown-formatted text into HTML. 
+	The input will be sanitized for any HTML tags first. 
+	Note that markdown parser will always surround the block in <p> tags,
+	and <p> tags are not allowed inside other <p> tags.
+*@
 @helper FormatMarkdown(string text) {
+	<!-- ko stopBinding -->
 	@Html.Raw(MarkdownParser.GetHtml(text))
+	<!-- /ko -->
 }
 
 @helper LanguageFlag(string languageCode) {

--- a/VocaDbWeb/Code/Markdown/MarkdownParser.cs
+++ b/VocaDbWeb/Code/Markdown/MarkdownParser.cs
@@ -40,7 +40,10 @@ namespace VocaDb.Web.Code.Markdown {
 		/// Transforms a block of text with Markdown. The input will be sanitized. The result will be cached.
 		/// </summary>
 		/// <param name="markdownText">Markdown text to be transformed. HTML will be encoded.</param>
-		/// <returns>Markdown-transformed text. This will include HTML.</returns>
+		/// <returns>
+		/// Markdown-transformed text. This will include HTML. 
+		/// The block is usually surrounded by "p" tags.
+		/// </returns>
 		public string GetHtml(string markdownText) {
 			
 			if (string.IsNullOrEmpty(markdownText))

--- a/VocaDbWeb/Scripts/KnockoutExtensions/StopBinding.ts
+++ b/VocaDbWeb/Scripts/KnockoutExtensions/StopBinding.ts
@@ -13,3 +13,6 @@ ko.bindingHandlers.stopBinding = {
         return { controlsDescendantBindings: true };
     }
 };
+
+// https://knockoutjs.com/documentation/custom-bindings-for-virtual-elements.html
+ko.virtualElements.allowedBindings.stopBinding = true;

--- a/VocaDbWeb/Views/Album/Details.cshtml
+++ b/VocaDbWeb/Views/Album/Details.cshtml
@@ -416,7 +416,7 @@
 							<h4 class="album-review-title">@Model.LatestReview.Title</h4>
 						}
 
-						<p>@HtmlHelpers.FormatMarkdown(Model.LatestReview.Text)</p>
+						<div>@HtmlHelpers.FormatMarkdown(Model.LatestReview.Text)</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Add StopBinding to all Markdown-formatted server-side rendered text.