### PR TITLE
Fix Bili playback controls; iframe all Bili player

### DIFF
--- a/VocaDbWeb/App_Code/PVHelpers.cshtml
+++ b/VocaDbWeb/App_Code/PVHelpers.cshtml
@@ -24,12 +24,16 @@
 	}
 }
 
-@helper EmbedBili(PVContract pv, string widthStr, string heightStr) {
+@helper EmbedBili(PVContract pv, int width, int height) {
 	var meta = pv.ExtendedMetadata != null ? pv.ExtendedMetadata.GetExtendedMetadata<BiliMetadata>() : null;
-	if (meta != null && meta.Cid != 0) {
-		<iframe src="https://player.bilibili.com/player.html?aid=@pv.PVId&cid=@meta.Cid&page=1" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="@widthStr" height="@heightStr"></iframe>
+		var widthStr = (width > 0 ? width.ToString() : "");
+	if (height >= 274 && width >= 480) {
+		var unmaskedHeight = height + 115;
+		var unmaskedHeightStr = (height > 0 ? unmaskedHeight.ToString() : "");
+		<div style="overflow:hidden"><iframe src="https://player.bilibili.com/player.html?aid=@pv.PVId&page=1" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="@widthStr" height="@unmaskedHeightStr" style="margin-top: -48px; margin-bottom: -38px"></iframe></div>
 	} else {
-		<embed height="@heightStr" width="@widthStr" quality="high" allowfullscreen="true" type="application/x-shockwave-flash" src="https://static.hdslb.com/miniloader.swf" flashvars="aid=@pv.PVId&page=1" pluginspage="https://www.adobe.com/shockwave/download/download.cgi?P1_Prod_Version=ShockwaveFlash" />
+		var heightStr = (width > 0 ? width.ToString() : "");
+		<iframe src="https://player.bilibili.com/player.html?aid=@pv.PVId&page=1" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="@widthStr" height="@heightStr"></iframe>
 	}
 }
 
@@ -44,7 +48,7 @@
 			break;
 
 		case PVService.Bilibili:
-			@EmbedBili(pv, widthStr, heightStr)
+			@EmbedBili(pv, width, height)
 			break;
 
 		case PVService.File:


### PR DESCRIPTION
The `cid` is in fact unnecessary for Bilibili iframe players (the `page` alone is sufficient for navigating in multi-page videos, see #494 ), and we can still enable the new `<iframe>` players without referring to `cid`s for songs who didn't got their `cid`s here (#495 ).

Bilibili playback controls will show up for `<iframe>`s larger than 480*360 (#372 ). If the frame is larger than the threshold, playback controls (29px in height) will start to show, and another two ad banners (one in the top, 48px in height; the other in the bottom, 38px in height) will also show up. My strategy would be simply masking the two ad banners away, so that we can get the playback controls back while also meeting the vocaDB size requirement (560*315).