### PR TITLE
Update the matcher for Bili user profile & Enable icons for all Bili subdomains

### DIFF
--- a/VocaDbModel/Service/VideoServices/VideoServiceBilibili.cs
+++ b/VocaDbModel/Service/VideoServices/VideoServiceBilibili.cs
@@ -98,6 +98,7 @@ namespace VocaDb.Model.Service.VideoServices {
 
 		public override IEnumerable<string> GetUserProfileUrls(string authorId) {
 			return new[] {
+				string.Format("https://space.bilibili.com/{0}", authorId),
 				string.Format("http://space.bilibili.com/{0}", authorId),
 				string.Format("http://space.bilibili.com/{0}/#!/index", authorId)
 			};

--- a/VocaDbWeb/Content/Styles/ExtLinks.css
+++ b/VocaDbWeb/Content/Styles/ExtLinks.css
@@ -29,12 +29,8 @@ a.extLink[href^="https://www5.atwiki.jp/hmiku/"],
 a.extLink[href^="https://w.atwiki.jp/hmiku/"] {
   background-image: url("/Content/ExtIcons/atwiki.png");
 }
-a.extLink[href^="http://space.bilibili.tv/"],
-a.extLink[href^="http://www.bilibili.tv/"],
-a.extLink[href^="http://space.bilibili.com/"],
-a.extLink[href^="https://space.bilibili.tv/"],
-a.extLink[href^="https://www.bilibili.tv/"],
-a.extLink[href^="https://space.bilibili.com/"] {
+a.extLink[href*="bilibili.tv/"],
+a.extLink[href*="bilibili.com/"]{
   background-image: url("/Content/ExtIcons/bilibili.png");
 }
 a.extLink[href*="booth.pm/"] {

--- a/VocaDbWeb/Content/Styles/ExtLinks.css
+++ b/VocaDbWeb/Content/Styles/ExtLinks.css
@@ -29,8 +29,8 @@ a.extLink[href^="https://www5.atwiki.jp/hmiku/"],
 a.extLink[href^="https://w.atwiki.jp/hmiku/"] {
   background-image: url("/Content/ExtIcons/atwiki.png");
 }
-a.extLink[href*="bilibili.tv/"],
-a.extLink[href*="bilibili.com/"]{
+a.extLink[href*=".bilibili.tv/"],
+a.extLink[href*=".bilibili.com/"]{
   background-image: url("/Content/ExtIcons/bilibili.png");
 }
 a.extLink[href*="booth.pm/"] {

--- a/VocaDbWeb/Content/Styles/ExtLinks.less
+++ b/VocaDbWeb/Content/Styles/ExtLinks.less
@@ -30,7 +30,7 @@ a.extLink {
 		background-image: url("/Content/ExtIcons/atwiki.png");
 	}
 
-	&[href^="http://space.bilibili.tv/"], &[href^="http://www.bilibili.tv/"], &[href^="http://space.bilibili.com/"], &[href^="https://space.bilibili.tv/"], &[href^="https://www.bilibili.tv/"], &[href^="https://space.bilibili.com/"] {
+	&[href*="bilibili.tv/"], &[href*="bilibili.com/"] {
 		.extLink(url("/Content/ExtIcons/bilibili.png"));
 	}
 

--- a/VocaDbWeb/Content/Styles/ExtLinks.less
+++ b/VocaDbWeb/Content/Styles/ExtLinks.less
@@ -30,7 +30,7 @@ a.extLink {
 		background-image: url("/Content/ExtIcons/atwiki.png");
 	}
 
-	&[href*="bilibili.tv/"], &[href*="bilibili.com/"] {
+	&[href*=".bilibili.tv/"], &[href*=".bilibili.com/"] {
 		.extLink(url("/Content/ExtIcons/bilibili.png"));
 	}
 


### PR DESCRIPTION
1. Most newly added Bilibili user profiles for artists go like `http://space.bilibili.com/nnn`. It would be great convenient to have them automatically matched when adding songs.

2. Many major subdomains (even including "http(s)://www.bilibili.com/" itself!) cannot have the icon shown in vocadb's pages, which is ridiculous.