### PR TITLE
Feat/564 normalize email addresses

### DIFF
--- a/Tests/Helpers/MailAddressNormalizerTests.cs
+++ b/Tests/Helpers/MailAddressNormalizerTests.cs
@@ -1,0 +1,86 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VocaDb.Model.Helpers;
+
+namespace VocaDb.Tests.Helpers {
+
+	/// <summary>
+	/// Code from https://github.com/iDoRecall/email-normalize/blob/0938e0a4710c6fc076c50dd42ea2886b2984e219/tests.js
+	/// </summary>
+	[TestClass]
+	public class MailAddressNormalizerTests {
+
+		private async Task<string> NormalizedAddress(string address, MailAddressNormalizerOptions options = MailAddressNormalizerOptions.None) {
+			return await MailAddressNormalizer.NormalizeAsync(address, options);
+		}
+
+		[TestMethod]
+		public async Task OnlySupportedDomains() {
+			Assert.AreEqual("a.b.c+tag@example.com", await NormalizedAddress("a.b.c+tag@example.com"));
+		}
+
+		[TestMethod]
+		public async Task GmailDots() {Assert.AreEqual("abc@gmail.com", await NormalizedAddress("a.b.c@gmail.com"));
+			Assert.AreEqual("a.b.c@yahoo.com", await NormalizedAddress("a.b.c@yahoo.com"));
+		}
+
+		[TestMethod]
+		public async Task Plus() {
+			Assert.AreEqual("abc@gmail.com", await NormalizedAddress("a.b.c+tag@gmail.com"));
+			Assert.AreEqual("a.b.c+tag@yahoo.com", await NormalizedAddress("a.b.c+tag@yahoo.com"));
+		}
+
+		[TestMethod]
+		public async Task NonStandardTlds() {
+			Assert.AreEqual("a.b.c+tag@something.co.uk", await NormalizedAddress("a.b.c+tag@something.co.uk"));
+			Assert.AreEqual("abc@something.co.uk", await NormalizedAddress("a.b.c+tag@something.co.uk", MailAddressNormalizerOptions.ForceRemoveDots | MailAddressNormalizerOptions.ForceRemoveTags));
+		}
+
+		[TestMethod]
+		public async Task Yahoo() {
+			Assert.AreEqual("a.b.c+tag@yahoo.com", await NormalizedAddress("a.b.c+tag@yahoo.com"));
+			Assert.AreEqual("a.b.c@yahoo.com", await NormalizedAddress("a.b.c-tag@yahoo.com"));
+			Assert.AreEqual("a.b.c@yahoo.co.uk", await NormalizedAddress("a.b.c-tag@yahoo.co.uk"));
+			Assert.AreEqual("a@yahoo.ro", await NormalizedAddress("a-b.c-tag@yahoo.ro"));
+		}
+
+		[TestMethod]
+		public async Task Microsoft() {
+			Assert.AreEqual("a.b.c@outlook.com", await NormalizedAddress("a.b.c+tag@outlook.com"));
+			Assert.AreEqual("a.b.c-tag@hotmail.com", await NormalizedAddress("a.b.c-tag@hotmail.com"));
+			Assert.AreEqual("a.b.c-tag@outlook.co.uk", await NormalizedAddress("a.b.c-tag@outlook.co.uk"));
+			Assert.AreEqual("a.b.c@live.com", await NormalizedAddress("a.b.c+d@live.com"));
+		}
+
+		[TestMethod]
+		public async Task GoogleAppsForWork() {
+			Assert.AreEqual("a.b.c+tag@idorecall.com", await NormalizedAddress("a.b.c+tag@idorecall.com"));
+			Assert.AreEqual("abc@blueseed.com", await NormalizedAddress("a.b.c+tag@blueseed.com", MailAddressNormalizerOptions.DetectProvider));
+		}
+
+		[TestMethod]
+		public async Task Fastmail() {
+			Assert.AreEqual("a.b.c@fastmail.com", await NormalizedAddress("a.b.c+tag@fastmail.com"));
+			Assert.AreEqual("a.b.c@fastmail.fm", await NormalizedAddress("a.b.c+tag@fastmail.fm"));
+			// http://outcoldman.com/en/archive/2014/05/08/fastmail/
+			Assert.AreEqual("denis+tag@outcoldman.com", await NormalizedAddress("denis+tag@outcoldman.com"));
+		}
+
+		[TestMethod]
+		public async Task AsyncTestGoogleAppsForWork() {
+			Assert.AreEqual("abc@blueseed.com", await NormalizedAddress("a.b.c+tag@blueseed.com", MailAddressNormalizerOptions.DetectProvider));
+		}
+
+		[TestMethod]
+		public async Task AsyncTestFastmail() {
+			Assert.AreEqual("notpublic@denis.gladkikh.email", await NormalizedAddress("notpublic+tag@denis.gladkikh.email", MailAddressNormalizerOptions.DetectProvider));
+		}
+
+		[TestMethod]
+		public async Task AsyncTestNoSpecialProvider() {
+			Assert.AreEqual("ad.missions+impossible@stanford.edu", await NormalizedAddress("ad.missions+impossible@stanford.edu", MailAddressNormalizerOptions.DetectProvider));
+		}
+
+	}
+
+}

--- a/Tests/Helpers/MailAddressNormalizerTests.cs
+++ b/Tests/Helpers/MailAddressNormalizerTests.cs
@@ -14,71 +14,75 @@ namespace VocaDb.Tests.Helpers {
 			return await MailAddressNormalizer.NormalizeAsync(address, options);
 		}
 
-		[TestMethod]
-		public async Task OnlySupportedDomains() {
-			Assert.AreEqual("a.b.c+tag@example.com", await NormalizedAddress("a.b.c+tag@example.com"));
+		private async void TestNormalizedEmail(string expected, string given, MailAddressNormalizerOptions options = MailAddressNormalizerOptions.None) {
+			Assert.AreEqual(expected, await NormalizedAddress(given, options));
 		}
 
 		[TestMethod]
-		public async Task GmailDots() {Assert.AreEqual("abc@gmail.com", await NormalizedAddress("a.b.c@gmail.com"));
-			Assert.AreEqual("a.b.c@yahoo.com", await NormalizedAddress("a.b.c@yahoo.com"));
+		public void OnlySupportedDomains() {
+			TestNormalizedEmail("a.b.c+tag@example.com", "a.b.c+tag@example.com");
 		}
 
 		[TestMethod]
-		public async Task Plus() {
-			Assert.AreEqual("abc@gmail.com", await NormalizedAddress("a.b.c+tag@gmail.com"));
-			Assert.AreEqual("a.b.c+tag@yahoo.com", await NormalizedAddress("a.b.c+tag@yahoo.com"));
+		public void GmailDots() {TestNormalizedEmail("abc@gmail.com", "a.b.c@gmail.com");
+			TestNormalizedEmail("a.b.c@yahoo.com", "a.b.c@yahoo.com");
 		}
 
 		[TestMethod]
-		public async Task NonStandardTlds() {
-			Assert.AreEqual("a.b.c+tag@something.co.uk", await NormalizedAddress("a.b.c+tag@something.co.uk"));
-			Assert.AreEqual("abc@something.co.uk", await NormalizedAddress("a.b.c+tag@something.co.uk", MailAddressNormalizerOptions.ForceRemoveDots | MailAddressNormalizerOptions.ForceRemoveTags));
+		public void Plus() {
+			TestNormalizedEmail("abc@gmail.com", "a.b.c+tag@gmail.com");
+			TestNormalizedEmail("a.b.c+tag@yahoo.com", "a.b.c+tag@yahoo.com");
 		}
 
 		[TestMethod]
-		public async Task Yahoo() {
-			Assert.AreEqual("a.b.c+tag@yahoo.com", await NormalizedAddress("a.b.c+tag@yahoo.com"));
-			Assert.AreEqual("a.b.c@yahoo.com", await NormalizedAddress("a.b.c-tag@yahoo.com"));
-			Assert.AreEqual("a.b.c@yahoo.co.uk", await NormalizedAddress("a.b.c-tag@yahoo.co.uk"));
-			Assert.AreEqual("a@yahoo.ro", await NormalizedAddress("a-b.c-tag@yahoo.ro"));
+		public void NonStandardTlds() {
+			TestNormalizedEmail("a.b.c+tag@something.co.uk", "a.b.c+tag@something.co.uk");
+			TestNormalizedEmail("abc@something.co.uk", "a.b.c+tag@something.co.uk", MailAddressNormalizerOptions.ForceRemoveDots | MailAddressNormalizerOptions.ForceRemoveTags);
 		}
 
 		[TestMethod]
-		public async Task Microsoft() {
-			Assert.AreEqual("a.b.c@outlook.com", await NormalizedAddress("a.b.c+tag@outlook.com"));
-			Assert.AreEqual("a.b.c-tag@hotmail.com", await NormalizedAddress("a.b.c-tag@hotmail.com"));
-			Assert.AreEqual("a.b.c-tag@outlook.co.uk", await NormalizedAddress("a.b.c-tag@outlook.co.uk"));
-			Assert.AreEqual("a.b.c@live.com", await NormalizedAddress("a.b.c+d@live.com"));
+		public void Yahoo() {
+			TestNormalizedEmail("a.b.c+tag@yahoo.com", "a.b.c+tag@yahoo.com");
+			TestNormalizedEmail("a.b.c@yahoo.com", "a.b.c-tag@yahoo.com");
+			TestNormalizedEmail("a.b.c@yahoo.co.uk", "a.b.c-tag@yahoo.co.uk");
+			TestNormalizedEmail("a@yahoo.ro", "a-b.c-tag@yahoo.ro");
 		}
 
 		[TestMethod]
-		public async Task GoogleAppsForWork() {
-			Assert.AreEqual("a.b.c+tag@idorecall.com", await NormalizedAddress("a.b.c+tag@idorecall.com"));
-			Assert.AreEqual("abc@blueseed.com", await NormalizedAddress("a.b.c+tag@blueseed.com", MailAddressNormalizerOptions.DetectProvider));
+		public void Microsoft() {
+			TestNormalizedEmail("a.b.c@outlook.com", "a.b.c+tag@outlook.com");
+			TestNormalizedEmail("a.b.c-tag@hotmail.com", "a.b.c-tag@hotmail.com");
+			TestNormalizedEmail("a.b.c-tag@outlook.co.uk", "a.b.c-tag@outlook.co.uk");
+			TestNormalizedEmail("a.b.c@live.com", "a.b.c+d@live.com");
 		}
 
 		[TestMethod]
-		public async Task Fastmail() {
-			Assert.AreEqual("a.b.c@fastmail.com", await NormalizedAddress("a.b.c+tag@fastmail.com"));
-			Assert.AreEqual("a.b.c@fastmail.fm", await NormalizedAddress("a.b.c+tag@fastmail.fm"));
+		public void GoogleAppsForWork() {
+			TestNormalizedEmail("a.b.c+tag@idorecall.com", "a.b.c+tag@idorecall.com");
+			TestNormalizedEmail("abc@blueseed.com", "a.b.c+tag@blueseed.com", MailAddressNormalizerOptions.DetectProvider);
+		}
+
+		[TestMethod]
+		public void Fastmail() {
+			TestNormalizedEmail("a.b.c@fastmail.com", "a.b.c+tag@fastmail.com");
+			TestNormalizedEmail("a.b.c@fastmail.fm", "a.b.c+tag@fastmail.fm");
 			// http://outcoldman.com/en/archive/2014/05/08/fastmail/
-			Assert.AreEqual("denis+tag@outcoldman.com", await NormalizedAddress("denis+tag@outcoldman.com"));
+			TestNormalizedEmail("denis+tag@outcoldman.com", "denis+tag@outcoldman.com");
 		}
 
 		[TestMethod]
-		public async Task AsyncTestGoogleAppsForWork() {
-			Assert.AreEqual("abc@blueseed.com", await NormalizedAddress("a.b.c+tag@blueseed.com", MailAddressNormalizerOptions.DetectProvider));
+		public void AsyncTestGoogleAppsForWork() {
+			TestNormalizedEmail("abc@blueseed.com", "a.b.c+tag@blueseed.com", MailAddressNormalizerOptions.DetectProvider);
 		}
 
 		[TestMethod]
-		public async Task AsyncTestFastmail() {
-			Assert.AreEqual("notpublic@denis.gladkikh.email", await NormalizedAddress("notpublic+tag@denis.gladkikh.email", MailAddressNormalizerOptions.DetectProvider));
+		public void AsyncTestFastmail() {
+			TestNormalizedEmail("notpublic@denis.gladkikh.email", "notpublic+tag@denis.gladkikh.email", MailAddressNormalizerOptions.DetectProvider);
 		}
 
 		[TestMethod]
-		public async Task AsyncTestNoSpecialProvider() {
-			Assert.AreEqual("ad.missions+impossible@stanford.edu", await NormalizedAddress("ad.missions+impossible@stanford.edu", MailAddressNormalizerOptions.DetectProvider));
+		public void AsyncTestNoSpecialProvider() {
+			TestNormalizedEmail("ad.missions+impossible@stanford.edu", "ad.missions+impossible@stanford.edu", MailAddressNormalizerOptions.DetectProvider);
 		}
 
 	}

--- a/Tests/Helpers/MailAddressNormalizerTests.cs
+++ b/Tests/Helpers/MailAddressNormalizerTests.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using VocaDb.Model.Helpers;
 
@@ -10,12 +9,12 @@ namespace VocaDb.Tests.Helpers {
 	[TestClass]
 	public class MailAddressNormalizerTests {
 
-		private async Task<string> NormalizedAddress(string address, MailAddressNormalizerOptions options = MailAddressNormalizerOptions.None) {
-			return await MailAddressNormalizer.NormalizeAsync(address, options);
+		private string NormalizedAddress(string address) {
+			return MailAddressNormalizer.Normalize(address);
 		}
 
-		private async void TestNormalizedEmail(string expected, string given, MailAddressNormalizerOptions options = MailAddressNormalizerOptions.None) {
-			Assert.AreEqual(expected, await NormalizedAddress(given, options));
+		private void TestNormalizedEmail(string expected, string given) {
+			Assert.AreEqual(expected, NormalizedAddress(given));
 		}
 
 		[TestMethod]
@@ -37,7 +36,6 @@ namespace VocaDb.Tests.Helpers {
 		[TestMethod]
 		public void NonStandardTlds() {
 			TestNormalizedEmail("a.b.c+tag@something.co.uk", "a.b.c+tag@something.co.uk");
-			TestNormalizedEmail("abc@something.co.uk", "a.b.c+tag@something.co.uk", MailAddressNormalizerOptions.ForceRemoveDots | MailAddressNormalizerOptions.ForceRemoveTags);
 		}
 
 		[TestMethod]
@@ -59,7 +57,6 @@ namespace VocaDb.Tests.Helpers {
 		[TestMethod]
 		public void GoogleAppsForWork() {
 			TestNormalizedEmail("a.b.c+tag@idorecall.com", "a.b.c+tag@idorecall.com");
-			TestNormalizedEmail("abc@blueseed.com", "a.b.c+tag@blueseed.com", MailAddressNormalizerOptions.DetectProvider);
 		}
 
 		[TestMethod]
@@ -68,21 +65,6 @@ namespace VocaDb.Tests.Helpers {
 			TestNormalizedEmail("a.b.c@fastmail.fm", "a.b.c+tag@fastmail.fm");
 			// http://outcoldman.com/en/archive/2014/05/08/fastmail/
 			TestNormalizedEmail("denis+tag@outcoldman.com", "denis+tag@outcoldman.com");
-		}
-
-		[TestMethod]
-		public void AsyncTestGoogleAppsForWork() {
-			TestNormalizedEmail("abc@blueseed.com", "a.b.c+tag@blueseed.com", MailAddressNormalizerOptions.DetectProvider);
-		}
-
-		[TestMethod]
-		public void AsyncTestFastmail() {
-			TestNormalizedEmail("notpublic@denis.gladkikh.email", "notpublic+tag@denis.gladkikh.email", MailAddressNormalizerOptions.DetectProvider);
-		}
-
-		[TestMethod]
-		public void AsyncTestNoSpecialProvider() {
-			TestNormalizedEmail("ad.missions+impossible@stanford.edu", "ad.missions+impossible@stanford.edu", MailAddressNormalizerOptions.DetectProvider);
 		}
 
 	}

--- a/Tests/VocaDb.Tests.csproj
+++ b/Tests/VocaDb.Tests.csproj
@@ -181,6 +181,7 @@
     <Compile Include="Domain\Images\ImageThumbGeneratorTests.cs" />
     <Compile Include="Helpers\EnumerableExtenderTests.cs" />
     <Compile Include="Helpers\LyricsHelperTests.cs" />
+    <Compile Include="Helpers\MailAddressNormalizerTests.cs" />
     <Compile Include="Helpers\RelatedSitesHelperTests.cs" />
     <Compile Include="Helpers\StringExtensionsTests.cs" />
     <Compile Include="Helpers\StringHelperTests.cs" />

--- a/VocaDb.Migrations/Migrations.cs
+++ b/VocaDb.Migrations/Migrations.cs
@@ -5,6 +5,15 @@ namespace VocaDb.Migrations {
 
 	// Migration version format: YYYY_MM_DD_HHmm
 
+	[Migration(2020_03_30_2300)]
+	public class UserNormalizedEmail : AutoReversingMigration {
+
+		public override void Up() {
+			Create.Column("NormalizedEmail").OnTable(TableNames.Users).AsString(50).NotNullable().WithDefaultValue(string.Empty);
+		}
+
+	}
+
 	[Migration(2020_03_22_0000)]
 	public class VenuesAddressCountryCode : AutoReversingMigration {
 

--- a/VocaDb.Migrations/Migrations.cs
+++ b/VocaDb.Migrations/Migrations.cs
@@ -15,7 +15,7 @@ namespace VocaDb.Migrations {
 	}
 
 	[Migration(2020_03_22_0000)]
-	public class VenuesAddressCountryCode : AutoReversingMigration {
+	public class VenueAddressCountryCode : AutoReversingMigration {
 
 		public override void Up() {
 			Create.Column("AddressCountryCode").OnTable(TableNames.Venues).AsString(10).NotNullable().WithDefaultValue(string.Empty);
@@ -24,7 +24,7 @@ namespace VocaDb.Migrations {
 	}
 
 	[Migration(2020_03_01_1300)]
-	public class ArchivedEventVersionsRenameVenue : Migration {
+	public class ArchivedReleaseEventRenameVenue : Migration {
 
 		public override void Up() {
 			Execute.Sql("UPDATE [ArchivedEventVersions] SET ChangedFields = REPLACE(ChangedFields, 'Venue', 'VenueName') WHERE ChangedFields LIKE '%Venue%' AND NOT ChangedFields LIKE '%VenueName%'");
@@ -37,7 +37,7 @@ namespace VocaDb.Migrations {
 	}
 
 	[Migration(2020_03_01_1000)]
-	public class VenuesCreateDate : AutoReversingMigration {
+	public class VenueCreateDate : AutoReversingMigration {
 
 		public override void Up() {
 			Create.Column("CreateDate").OnTable(TableNames.Venues).AsDateTime().NotNullable().WithDefault(SystemMethods.CurrentDateTime);
@@ -46,7 +46,7 @@ namespace VocaDb.Migrations {
 	}
 
 	[Migration(2020_02_28_1700)]
-	public class AlbumReleaseEventsRenameVenue : AutoReversingMigration {
+	public class ReleaseEventRenameVenue : AutoReversingMigration {
 
 		public override void Up() {
 			Rename.Column("[Venue]").OnTable(TableNames.AlbumReleaseEvents).To("VenueName");

--- a/VocaDbModel/Database/Queries/UserQueries.cs
+++ b/VocaDbModel/Database/Queries/UserQueries.cs
@@ -713,7 +713,8 @@ namespace VocaDb.Model.Database.Queries {
 
 					ValidateEmail(email);
 
-					existing = await ctx.Query().Where(u => u.Active && u.Email == email).VdbFirstOrDefaultAsync();
+					var normalizedEmail = await MailAddressNormalizer.NormalizeAsync(email);
+					existing = await ctx.Query().Where(u => u.Active && u.NormalizedEmail == normalizedEmail).VdbFirstOrDefaultAsync();
 
 					if (existing != null)
 						throw new UserEmailAlreadyExistsException();
@@ -810,7 +811,8 @@ namespace VocaDb.Model.Database.Queries {
 
 					ValidateEmail(email);
 
-					existing = ctx.Query().FirstOrDefault(u => u.Active && u.Email == email);
+					var normalizedEmail = MailAddressNormalizer.Normalize(email);
+					existing = ctx.Query().FirstOrDefault(u => u.Active && u.NormalizedEmail == normalizedEmail);
 
 					if (existing != null)
 						throw new UserEmailAlreadyExistsException();
@@ -1573,6 +1575,7 @@ namespace VocaDb.Model.Database.Queries {
 
 				user.Active = contract.Active;
 				user.Email = contract.Email;
+				user.NormalizedEmail = !string.IsNullOrEmpty(contract.Email) ? MailAddressNormalizer.Normalize(contract.Email) : string.Empty;
 				user.Options.Poisoned = contract.Poisoned;
 				user.Options.Supporter = contract.Supporter;
 
@@ -1773,7 +1776,8 @@ namespace VocaDb.Model.Database.Queries {
 
 					ValidateEmail(email);
 
-					var existing = ctx.Query().FirstOrDefault(u => u.Active && u.Id != user.Id && u.Email == email);
+					var normalizedEmail = MailAddressNormalizer.Normalize(email);
+					var existing = ctx.Query().FirstOrDefault(u => u.Active && u.Id != user.Id && u.NormalizedEmail == normalizedEmail);
 
 					if (existing != null)
 						throw new UserEmailAlreadyExistsException();

--- a/VocaDbModel/Database/Queries/UserQueries.cs
+++ b/VocaDbModel/Database/Queries/UserQueries.cs
@@ -713,7 +713,7 @@ namespace VocaDb.Model.Database.Queries {
 
 					ValidateEmail(email);
 
-					var normalizedEmail = await MailAddressNormalizer.NormalizeAsync(email);
+					var normalizedEmail = MailAddressNormalizer.Normalize(email);
 					existing = await ctx.Query().Where(u => u.Active && u.NormalizedEmail == normalizedEmail).VdbFirstOrDefaultAsync();
 
 					if (existing != null)

--- a/VocaDbModel/Domain/Users/User.cs
+++ b/VocaDbModel/Domain/Users/User.cs
@@ -362,7 +362,7 @@ namespace VocaDb.Model.Domain.Users {
 		}
 
 		/// <summary>
-		/// Normalized email address.
+		/// Normalized email address (email address without "+" and/or dots).
 		/// </summary>
 		public virtual string NormalizedEmail {
 			get => normalizedEmail;

--- a/VocaDbModel/Domain/Users/User.cs
+++ b/VocaDbModel/Domain/Users/User.cs
@@ -50,6 +50,7 @@ namespace VocaDb.Model.Domain.Users {
 		private IList<UserMessage> messages = new List<UserMessage>();
 		private string name;
 		private string nameLc;
+		private string normalizedEmail;
 		private IList<OldUsername> oldUsernames = new List<OldUsername>();
 		private UserOptions options;
 		private IList<OwnedArtistForUser> ownedArtists = new List<OwnedArtistForUser>(); 
@@ -78,6 +79,7 @@ namespace VocaDb.Model.Domain.Users {
 			Culture = string.Empty;
 			DefaultLanguageSelection = ContentLanguagePreference.Default;
 			Email = string.Empty;
+			NormalizedEmail = string.Empty;
 			EmailOptions = UserEmailOptions.PrivateMessagesFromAll;
 			GroupId = UserGroupId.Regular;
 			Language = OptionalCultureCode.Empty;
@@ -102,6 +104,7 @@ namespace VocaDb.Model.Domain.Users {
 			Name = name;
 			NameLC = name.ToLowerInvariant();
 			Email = email;
+			NormalizedEmail = !string.IsNullOrEmpty(email) ? MailAddressNormalizer.Normalize(email) : string.Empty;
 
 			UpdatePassword(pass, passwordHashAlgorithm);
 
@@ -355,6 +358,17 @@ namespace VocaDb.Model.Domain.Users {
 			set {
 				ParamIs.NotNullOrEmpty(() => value);
 				nameLc = value;
+			}
+		}
+
+		/// <summary>
+		/// Normalized email address.
+		/// </summary>
+		public virtual string NormalizedEmail {
+			get => normalizedEmail;
+			set {
+				ParamIs.NotNull(() => value);
+				normalizedEmail = value;
 			}
 		}
 

--- a/VocaDbModel/Domain/Users/User.cs
+++ b/VocaDbModel/Domain/Users/User.cs
@@ -662,6 +662,7 @@ namespace VocaDb.Model.Domain.Users {
 
 			if (!string.Equals(Email, newEmail, StringComparison.InvariantCultureIgnoreCase)) {
 				Email = newEmail;
+				NormalizedEmail = !string.IsNullOrEmpty(newEmail) ? MailAddressNormalizer.Normalize(newEmail) : string.Empty;
 				Options.EmailVerified = false;				
 			}
 

--- a/VocaDbModel/Helpers/MailAddressNormalizer.cs
+++ b/VocaDbModel/Helpers/MailAddressNormalizer.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Mail;
+using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+using DnsClient;
+
+namespace VocaDb.Model.Helpers {
+
+	[Flags]
+	public enum MailAddressNormalizerOptions {
+		None = 0,
+		ForceRemoveDots = 1,
+		ForceRemoveTags = 2,
+		DetectProvider = 4
+	}
+
+	/// <summary>
+	/// Code from https://github.com/iDoRecall/email-normalize/blob/0938e0a4710c6fc076c50dd42ea2886b2984e219/email.js
+	/// </summary>
+	public static class MailAddressNormalizer {
+
+		public static readonly Dictionary<string, char> hostsWithTags = new Dictionary<string, char> {
+			// Google only has two Gmail domains: https://en.wikipedia.org/wiki/List_of_Google_domains
+			{ "gmail.com", '+' },
+			{ "googlemail.com", '+' },
+			{ "google.com", '+' },  // corporate email addresses; TODO presumably country domains also receive corporate email?
+			// Microsoft
+			{ "outlook.com", '+' },
+			{ "hotmail.com", '+' },
+			{ "live.com", '+' },
+			// Fastmail - https://www.fastmail.com/help/receive/addressing.html TODO: whatever@username.fastmail.com -> username@fastmail.com
+			{ "fastmail.com", '+' },
+			{ "fastmail.fm", '+' },
+			// Yahoo Mail Plus accounts, per https://en.wikipedia.org/wiki/Yahoo!_Mail#Email_domains, use hyphens - http://www.cnet.com/forums/discussions/did-yahoo-break-disposable-email-addresses-mail-plus-395088/
+			{ "yahoo.com.ar", '-' },
+			{ "yahoo.com.au", '-' },
+			{ "yahoo.at", '-' },
+			{ "yahoo.be/fr", '-' },
+			{ "yahoo.be/nl", '-' },
+			{ "yahoo.com.br", '-' },
+			{ "ca.yahoo.com", '-' },
+			{ "qc.yahoo.com", '-' },
+			{ "yahoo.com.co", '-' },
+			{ "yahoo.com.hr", '-' },
+			{ "yahoo.cz", '-' },
+			{ "yahoo.dk", '-' },
+			{ "yahoo.fi", '-' },
+			{ "yahoo.fr", '-' },
+			{ "yahoo.de", '-' },
+			{ "yahoo.gr", '-' },
+			{ "yahoo.com.hk", '-' },
+			{ "yahoo.hu", '-' },
+			{ "yahoo.co.in/yahoo.in", '-' },
+			{ "yahoo.co.id", '-' },
+			{ "yahoo.ie", '-' },
+			{ "yahoo.co.il", '-' },
+			{ "yahoo.it", '-' },
+			{ "yahoo.co.jp", '-' },
+			{ "yahoo.com.my", '-' },
+			{ "yahoo.com.mx", '-' },
+			{ "yahoo.ae", '-' },
+			{ "yahoo.nl", '-' },
+			{ "yahoo.co.nz", '-' },
+			{ "yahoo.no", '-' },
+			{ "yahoo.com.ph", '-' },
+			{ "yahoo.pl", '-' },
+			{ "yahoo.pt", '-' },
+			{ "yahoo.ro", '-' },
+			{ "yahoo.ru", '-' },
+			{ "yahoo.com.sg", '-' },
+			{ "yahoo.co.za", '-' },
+			{ "yahoo.es", '-' },
+			{ "yahoo.se", '-' },
+			{ "yahoo.ch/fr", '-' },
+			{ "yahoo.ch/de", '-' },
+			{ "yahoo.com.tw", '-' },
+			{ "yahoo.co.th", '-' },
+			{ "yahoo.com.tr", '-' },
+			{ "yahoo.co.uk", '-' },
+			{ "yahoo.com", '-' },
+			{ "yahoo.com.vn", '-' }
+		};
+
+		public static string Normalize(MailAddress address, MailAddressNormalizerOptions options = MailAddressNormalizerOptions.None) => NormalizeAsync(address, options).Result;
+
+		public static string Normalize(string address, MailAddressNormalizerOptions options = MailAddressNormalizerOptions.None) => NormalizeAsync(address, options).Result;
+
+		public static async Task<string> NormalizeAsync(MailAddress address, MailAddressNormalizerOptions options = MailAddressNormalizerOptions.None) {
+			var user = address.User;
+			var host = address.Host.ToLower();
+
+			if (options.HasFlag(MailAddressNormalizerOptions.ForceRemoveTags))
+				user = Regex.Replace(user, @"[-+=].*", "");
+			else {
+				if (hostsWithTags.TryGetValue(host, out var separator))
+					user = user.Split(separator)[0];
+			}
+
+			if (options.HasFlag(MailAddressNormalizerOptions.ForceRemoveDots) || Regex.IsMatch(host, @"^(gmail|googlemail|google)\.com$"))
+				user = Regex.Replace(user, @"\.", "");
+
+			if (host == "googlemail.com")
+				host = "gmail.com";
+
+			if (options.HasFlag(MailAddressNormalizerOptions.DetectProvider)) {
+				// Detect custom domain email hosting providers TODO providers from https://news.ycombinator.com/item?id=8533588
+
+				static string ProcessMXRecords(DnsString exchange, string user) {
+					if (Regex.IsMatch(exchange.Value, @"aspmx.*google.*\.com\.?$", RegexOptions.IgnoreCase))
+						return Regex.Replace(user.Split('+')[0], @"\.", "");
+
+					if (Regex.IsMatch(exchange.Value, @"\.messagingengine\.com\.?$", RegexOptions.IgnoreCase))
+						return user.Split('+')[0];
+
+					return user;
+				}
+
+				var client = new LookupClient();
+				var result = await client.QueryAsync(host, QueryType.MX);
+
+				foreach (var record in result.Answers.MxRecords())
+					user = ProcessMXRecords(record.Exchange, user);
+
+				return user + "@" + host;
+			}
+
+			return user + "@" + host;
+		}
+
+		public static async Task<string> NormalizeAsync(string address, MailAddressNormalizerOptions options = MailAddressNormalizerOptions.None) => await NormalizeAsync(new MailAddress(address), options);
+
+	}
+
+}

--- a/VocaDbModel/Mapping/Users/UserMap.cs
+++ b/VocaDbModel/Mapping/Users/UserMap.cs
@@ -23,6 +23,7 @@ namespace VocaDb.Model.Mapping.Users {
 			Map(m => m.LastLogin).Not.Nullable();
 			Map(m => m.Name).Length(100).Not.Nullable();
 			Map(m => m.NameLC).Length(100).Not.Nullable();
+			Map(m => m.NormalizedEmail).Length(50).Not.Nullable();
 			Map(m => m.Password).Length(50).Not.Nullable();
 			Map(m => m.PasswordHashAlgorithm).Not.Nullable();
 			Map(m => m.PreferredVideoService).Not.Nullable();

--- a/VocaDbModel/Service/AdminService.cs
+++ b/VocaDbModel/Service/AdminService.cs
@@ -594,6 +594,25 @@ namespace VocaDb.Model.Service {
 
 		}
 
+		public void UpdateNormalizedEmailAddresses() {
+
+			PermissionContext.VerifyPermission(PermissionToken.Admin);
+
+			HandleTransaction(session => {
+
+				AuditLog("updating normalized email addresses", session);
+
+				var users = session.Query<User>().ToArray();
+
+				foreach (var user in users) {
+					user.NormalizedEmail = !string.IsNullOrEmpty(user.Email) ? MailAddressNormalizer.Normalize(user.Email) : string.Empty;
+					session.Update(user);
+				}
+
+			});
+
+		}
+
 		public void UpdatePVIcons() {
 
 			VerifyAdmin();

--- a/VocaDbModel/VocaDb.Model.csproj
+++ b/VocaDbModel/VocaDb.Model.csproj
@@ -41,9 +41,6 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="DnsClient, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4574bb5573c51424, processorArchitecture=MSIL">
-      <HintPath>..\packages\DnsClient.1.3.0\lib\net471\DnsClient.dll</HintPath>
-    </Reference>
     <Reference Include="FluentNHibernate, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentNHibernate.2.1.2\lib\net461\FluentNHibernate.dll</HintPath>
     </Reference>
@@ -98,9 +95,6 @@
       <HintPath>..\Libs\RSS.NET.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
-    </Reference>
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\packages\Microsoft.Bcl.Immutable.1.0.34\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>

--- a/VocaDbModel/VocaDb.Model.csproj
+++ b/VocaDbModel/VocaDb.Model.csproj
@@ -41,6 +41,9 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
+    <Reference Include="DnsClient, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4574bb5573c51424, processorArchitecture=MSIL">
+      <HintPath>..\packages\DnsClient.1.3.0\lib\net471\DnsClient.dll</HintPath>
+    </Reference>
     <Reference Include="FluentNHibernate, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentNHibernate.2.1.2\lib\net461\FluentNHibernate.dll</HintPath>
     </Reference>
@@ -95,6 +98,9 @@
       <HintPath>..\Libs\RSS.NET.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\packages\Microsoft.Bcl.Immutable.1.0.34\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
@@ -628,6 +634,7 @@
     <Compile Include="Helpers\LambdaComparer.cs" />
     <Compile Include="Helpers\LocalizedStringHelper.cs" />
     <Compile Include="Helpers\LyricsHelper.cs" />
+    <Compile Include="Helpers\MailAddressNormalizer.cs" />
     <Compile Include="Helpers\NameHelper.cs" />
     <Compile Include="Helpers\ObjectHelper.cs" />
     <Compile Include="Helpers\OtherHelper.cs" />

--- a/VocaDbModel/packages.config
+++ b/VocaDbModel/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net471" />
+  <package id="DnsClient" version="1.3.0" targetFramework="net48" />
   <package id="FluentNHibernate" version="2.1.2" targetFramework="net471" />
   <package id="HtmlAgilityPack" version="1.9.2" targetFramework="net472" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net471" />
@@ -15,5 +16,6 @@
   <package id="PiaproClient" version="2.2.0" targetFramework="net48" />
   <package id="Remotion.Linq" version="2.2.0" targetFramework="net472" />
   <package id="Remotion.Linq.EagerFetching" version="2.2.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net48" />
   <package id="taglib" version="2.1.0.0" targetFramework="net46" />
 </packages>

--- a/VocaDbModel/packages.config
+++ b/VocaDbModel/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net471" />
-  <package id="DnsClient" version="1.3.0" targetFramework="net48" />
   <package id="FluentNHibernate" version="2.1.2" targetFramework="net471" />
   <package id="HtmlAgilityPack" version="1.9.2" targetFramework="net472" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net471" />
@@ -16,6 +15,5 @@
   <package id="PiaproClient" version="2.2.0" targetFramework="net48" />
   <package id="Remotion.Linq" version="2.2.0" targetFramework="net472" />
   <package id="Remotion.Linq.EagerFetching" version="2.2.0" targetFramework="net472" />
-  <package id="System.Buffers" version="4.4.0" targetFramework="net48" />
   <package id="taglib" version="2.1.0.0" targetFramework="net46" />
 </packages>

--- a/VocaDbWeb/Controllers/AdminController.cs
+++ b/VocaDbWeb/Controllers/AdminController.cs
@@ -267,6 +267,14 @@ namespace VocaDb.Web.Controllers
 
 		}
 
+		public ActionResult UpdateNormalizedEmailAddresses() {
+
+			Service.UpdateNormalizedEmailAddresses();
+
+			return RedirectToAction("Index");
+
+		}
+
 		public ActionResult UpdatePVIcons() {
 
 			Service.UpdatePVIcons();


### PR DESCRIPTION
#564 I ported [iDoRecall:email-normalize](https://github.com/iDoRecall/email-normalize) to C# by using [DnsClient.NET](https://github.com/MichaCo/DnsClient.NET). However, if the [DetectProvider](https://github.com/ycanardeau/vocadb/blob/3aad17a56ffa8209c5a9a7502468adb49a38b995/VocaDbModel/Helpers/MailAddressNormalizer.cs#L16) flag is set as the second argument of Normalize or NormalizeAsync, the program freezes at [LookupClient.QueryAsync](https://github.com/ycanardeau/vocadb/blob/3aad17a56ffa8209c5a9a7502468adb49a38b995/VocaDbModel/Helpers/MailAddressNormalizer.cs#L121) for some reason, even though their tests have passed. Additionally, we have to update the NormalizedEmail field for existing users somehow.