### PR TITLE
Update Bilibili player outlay: remove top banner mask

### DIFF
--- a/VocaDbWeb/App_Code/PVHelpers.cshtml
+++ b/VocaDbWeb/App_Code/PVHelpers.cshtml
@@ -28,9 +28,9 @@
 	var meta = pv.ExtendedMetadata != null ? pv.ExtendedMetadata.GetExtendedMetadata<BiliMetadata>() : null;
 		var widthStr = (width > 0 ? width.ToString() : "");
 	if (height >= 274 && width >= 480) {
-		var unmaskedHeight = height + 115;
+		var unmaskedHeight = height + 67;
 		var unmaskedHeightStr = (height > 0 ? unmaskedHeight.ToString() : "");
-		<div style="overflow:hidden; width:max-content; height:max-content"><iframe src="https://player.bilibili.com/player.html?aid=@pv.PVId&page=1" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="@widthStr" height="@unmaskedHeightStr" style="margin-top:-48px; margin-bottom:-38px; width:@(widthStr)px; height:@(unmaskedHeightStr)px; position: relative"></iframe></div>
+		<div style="overflow:hidden; width:max-content; height:max-content"><iframe src="https://player.bilibili.com/player.html?aid=@pv.PVId&page=1" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="@widthStr" height="@unmaskedHeightStr" style="margin-bottom:-38px; width:@(widthStr)px; height:@(unmaskedHeightStr)px"></iframe></div>
 	} else {
 		var heightStr = (width > 0 ? width.ToString() : "");
 		<iframe src="https://player.bilibili.com/player.html?aid=@pv.PVId&page=1" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="@widthStr" height="@heightStr"></iframe>


### PR DESCRIPTION
The Bilibili iframe player has removed the top banner ads, so we remove the obsolete -48px top margin.