### PR TITLE
Remove pre-build events

### DIFF
--- a/VocaDbWeb/VocaDbWeb.csproj
+++ b/VocaDbWeb/VocaDbWeb.csproj
@@ -1820,8 +1820,4 @@
     <TypeScriptLib>es2015,dom</TypeScriptLib>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets" />
-  <PropertyGroup>
-    <PreBuildEvent>if $(ConfigurationName) == Debug npm run css-dev &amp;&amp; npm run dev
-if $(ConfigurationName) == Release npm run css-prod &amp;&amp; npm run prod</PreBuildEvent>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Removed pre-build events. Now that we have to manually use `npm run css-dev && npm run dev` for debug or `npm run css-prod && npm run prod` for release to compile static assets (e.g. less and ts files).