### PR TITLE
Encode and parse json

### DIFF
--- a/VocaDbWeb.Core/Code/VocaDbPage.cs
+++ b/VocaDbWeb.Core/Code/VocaDbPage.cs
@@ -1,6 +1,7 @@
 #nullable disable
 
 using System.Threading;
+using System.Web;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Razor;
@@ -62,12 +63,12 @@ namespace VocaDb.Web.Code
 
 		public IHtmlContent ToJS(string str)
 		{
-			return new HtmlString(JsonHelpers.Serialize(str));
+			return new HtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(str))}"")");
 		}
 
 		public IHtmlContent ToJS(object obj)
 		{
-			return new HtmlString(JsonHelpers.Serialize(obj));
+			return new HtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(obj))}"")");
 		}
 
 		public VocaUrlMapper UrlMapper => new VocaUrlMapper();
@@ -112,12 +113,12 @@ namespace VocaDb.Web.Code
 
 		public IHtmlContent ToJS(string str)
 		{
-			return new HtmlString(JsonHelpers.Serialize(str));
+			return new HtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(str))}"")");
 		}
 
 		public IHtmlContent ToJS(object obj)
 		{
-			return new HtmlString(JsonHelpers.Serialize(obj));
+			return new HtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(obj))}"")");
 		}
 
 		public VocaUrlMapper UrlMapper => new VocaUrlMapper();

--- a/VocaDbWeb.Core/Code/VocaDbPage.cs
+++ b/VocaDbWeb.Core/Code/VocaDbPage.cs
@@ -1,7 +1,6 @@
 #nullable disable
 
 using System.Threading;
-using System.Web;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Razor;
@@ -61,15 +60,9 @@ namespace VocaDb.Web.Code
 			return val.HasValue ? val.ToString() : "null";
 		}
 
-		public IHtmlContent ToJS(string str)
-		{
-			return new HtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(str))}"")");
-		}
+		public IHtmlContent ToJS(string str) => JsonHelpers.ToJS(str);
 
-		public IHtmlContent ToJS(object obj)
-		{
-			return new HtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(obj))}"")");
-		}
+		public IHtmlContent ToJS(object obj) => JsonHelpers.ToJS(obj);
 
 		public VocaUrlMapper UrlMapper => new VocaUrlMapper();
 
@@ -111,15 +104,9 @@ namespace VocaDb.Web.Code
 			return val.HasValue ? val.ToString() : "null";
 		}
 
-		public IHtmlContent ToJS(string str)
-		{
-			return new HtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(str))}"")");
-		}
+		public IHtmlContent ToJS(string str) => JsonHelpers.ToJS(str);
 
-		public IHtmlContent ToJS(object obj)
-		{
-			return new HtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(obj))}"")");
-		}
+		public IHtmlContent ToJS(object obj) => JsonHelpers.ToJS(obj);
 
 		public VocaUrlMapper UrlMapper => new VocaUrlMapper();
 

--- a/VocaDbWeb.Core/Helpers/JsonHelpers.cs
+++ b/VocaDbWeb.Core/Helpers/JsonHelpers.cs
@@ -1,5 +1,7 @@
 #nullable disable
 
+using System.Web;
+using Microsoft.AspNetCore.Html;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
@@ -20,5 +22,10 @@ namespace VocaDb.Web.Helpers
 
 			return JsonConvert.SerializeObject(value, Formatting.None, settings);
 		}
+
+		/// <summary>
+		/// <seealso href="https://github.com/VocaDB/vocadb/pull/736"/>
+		/// </summary>
+		public static IHtmlContent ToJS(object value, bool lowerCase = true, bool dateTimeConverter = false) => new HtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(Serialize(value, lowerCase, dateTimeConverter))}"")");
 	}
 }

--- a/VocaDbWeb.Core/Helpers/ResourceHelpers.cs
+++ b/VocaDbWeb.Core/Helpers/ResourceHelpers.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Resources;
-using System.Web;
 using Microsoft.AspNetCore.Html;
 
 namespace VocaDb.Web.Helpers
@@ -21,7 +20,7 @@ namespace VocaDb.Web.Helpers
 		{
 			var dic = ToDict(resourceManager);
 
-			return new HtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(dic, lowerCase))}"")");
+			return JsonHelpers.ToJS(dic, lowerCase);
 		}
 	}
 }

--- a/VocaDbWeb.Core/Helpers/ResourceHelpers.cs
+++ b/VocaDbWeb.Core/Helpers/ResourceHelpers.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Resources;
+using System.Web;
 using Microsoft.AspNetCore.Html;
 
 namespace VocaDb.Web.Helpers
@@ -20,7 +21,7 @@ namespace VocaDb.Web.Helpers
 		{
 			var dic = ToDict(resourceManager);
 
-			return new HtmlString(JsonHelpers.Serialize(dic, lowerCase));
+			return new HtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(dic, lowerCase))}"")");
 		}
 	}
 }

--- a/VocaDbWeb/Code/HelperPage.cs
+++ b/VocaDbWeb/Code/HelperPage.cs
@@ -25,10 +25,7 @@ namespace VocaDb.Web.Code
 			return new MvcHtmlString(val ? "true" : "false");
 		}
 
-		public static IHtmlString ToJS(string str)
-		{
-			return new MvcHtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(str))}"")");
-		}
+		public static IHtmlString ToJS(string str) => JsonHelpers.ToJS(str);
 
 		public static UrlHelper Url => ((WebViewPage)WebPageContext.Current.Page).Url;
 

--- a/VocaDbWeb/Code/HelperPage.cs
+++ b/VocaDbWeb/Code/HelperPage.cs
@@ -27,7 +27,7 @@ namespace VocaDb.Web.Code
 
 		public static IHtmlString ToJS(string str)
 		{
-			return new MvcHtmlString(JsonHelpers.Serialize(str));
+			return new MvcHtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(str))}"")");
 		}
 
 		public static UrlHelper Url => ((WebViewPage)WebPageContext.Current.Page).Url;

--- a/VocaDbWeb/Code/VocaDbPage.cs
+++ b/VocaDbWeb/Code/VocaDbPage.cs
@@ -57,12 +57,12 @@ namespace VocaDb.Web.Code
 
 		public IHtmlString ToJS(string str)
 		{
-			return new MvcHtmlString(JsonHelpers.Serialize(str));
+			return new MvcHtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(str))}"")");
 		}
 
 		public IHtmlString ToJS(object obj)
 		{
-			return new MvcHtmlString(JsonHelpers.Serialize(obj));
+			return new MvcHtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(obj))}"")");
 		}
 
 		public VocaUrlMapper UrlMapper => new VocaUrlMapper();
@@ -99,12 +99,12 @@ namespace VocaDb.Web.Code
 
 		public IHtmlString ToJS(string str)
 		{
-			return new MvcHtmlString(JsonHelpers.Serialize(str));
+			return new MvcHtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(str))}"")");
 		}
 
 		public IHtmlString ToJS(object obj)
 		{
-			return new MvcHtmlString(JsonHelpers.Serialize(obj));
+			return new MvcHtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(obj))}"")");
 		}
 
 		public VocaUrlMapper UrlMapper => new VocaUrlMapper();

--- a/VocaDbWeb/Code/VocaDbPage.cs
+++ b/VocaDbWeb/Code/VocaDbPage.cs
@@ -55,15 +55,9 @@ namespace VocaDb.Web.Code
 			return val.HasValue ? val.ToString() : "null";
 		}
 
-		public IHtmlString ToJS(string str)
-		{
-			return new MvcHtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(str))}"")");
-		}
+		public IHtmlString ToJS(string str) => JsonHelpers.ToJS(str);
 
-		public IHtmlString ToJS(object obj)
-		{
-			return new MvcHtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(obj))}"")");
-		}
+		public IHtmlString ToJS(object obj) => JsonHelpers.ToJS(obj);
 
 		public VocaUrlMapper UrlMapper => new VocaUrlMapper();
 
@@ -97,15 +91,9 @@ namespace VocaDb.Web.Code
 			return val.HasValue ? val.ToString() : "null";
 		}
 
-		public IHtmlString ToJS(string str)
-		{
-			return new MvcHtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(str))}"")");
-		}
+		public IHtmlString ToJS(string str) => JsonHelpers.ToJS(str);
 
-		public IHtmlString ToJS(object obj)
-		{
-			return new MvcHtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(obj))}"")");
-		}
+		public IHtmlString ToJS(object obj) => JsonHelpers.ToJS(obj);
 
 		public VocaUrlMapper UrlMapper => new VocaUrlMapper();
 

--- a/VocaDbWeb/Helpers/JsonHelpers.cs
+++ b/VocaDbWeb/Helpers/JsonHelpers.cs
@@ -1,5 +1,7 @@
 #nullable disable
 
+using System.Web;
+using System.Web.Mvc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
@@ -20,5 +22,10 @@ namespace VocaDb.Web.Helpers
 
 			return JsonConvert.SerializeObject(value, Formatting.None, settings);
 		}
+
+		/// <summary>
+		/// <seealso href="https://github.com/VocaDB/vocadb/pull/736"/>
+		/// </summary>
+		public static IHtmlString ToJS(object value, bool lowerCase = true, bool dateTimeConverter = false) => new MvcHtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(Serialize(value, lowerCase, dateTimeConverter))}"")");
 	}
 }

--- a/VocaDbWeb/Helpers/ResourceHelpers.cs
+++ b/VocaDbWeb/Helpers/ResourceHelpers.cs
@@ -21,7 +21,7 @@ namespace VocaDb.Web.Helpers
 		{
 			var dic = ToDict(resourceManager);
 
-			return new MvcHtmlString(JsonHelpers.Serialize(dic, lowerCase));
+			return new MvcHtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(dic, lowerCase))}"")");
 		}
 	}
 }

--- a/VocaDbWeb/Helpers/ResourceHelpers.cs
+++ b/VocaDbWeb/Helpers/ResourceHelpers.cs
@@ -21,7 +21,7 @@ namespace VocaDb.Web.Helpers
 		{
 			var dic = ToDict(resourceManager);
 
-			return new MvcHtmlString($@"JSON.parse(""{HttpUtility.JavaScriptStringEncode(JsonHelpers.Serialize(dic, lowerCase))}"")");
+			return JsonHelpers.ToJS(dic, lowerCase);
 		}
 	}
 }


### PR DESCRIPTION
We have a piece of code like this:
```javascript
<script type="text/javascript">
    $(function () {
        var jsonModel = {"name": "<script>alert('Kazemachi Hello World');</script>"};
        var latestComments = [{"message": "<script>alert('BadBye');</script>"}];
    }
</script>
```

The problem here is that the first `</script>` tag is interpreted as a closing tag. So we have actually two `<script>` blocks,
```javascript
<script type="text/javascript">
    $(function () {
        var jsonModel = {"name": "<script>alert('Kazemachi Hello World');</script>
```
and
```javascript
<script>alert('BadBye');</script>
```
That's why `alert('BadBye');` is executed. 

We have to escape the JSON somehow, but the strings generated by `HttpUtility.JavaScriptStringEncode` cannot be directly used in `<script>`:
`{\"name\": \"\u003cscript\u003ealert(\u0027Kazemachi Hello World\u0027);\u003c/script\u003e\"}` and `[{\"message\": \"\u003cscript\u003ealert(\u0027BadBye\u0027);\u003c/script\u003e\"}]`

However, this is a valid JSON string that can be parsed by `JSON.parse` in most browsers:
```javascript
var jsonModel = JSON.parse("{\"name\": \"\u003cscript\u003ealert(\u0027Kazemachi Hello World\u0027);\u003c/script\u003e\"}");
var latestComments = JSON.parse("[{\"message\": \"\u003cscript\u003ealert(\u0027BadBye\u0027);\u003c/script\u003e\"}]");
```