### PR TITLE
Fix ManageIPRules

### DIFF
--- a/VocaDbWeb.Core/Views/Admin/ManageIPRules.cshtml
+++ b/VocaDbWeb.Core/Views/Admin/ManageIPRules.cshtml
@@ -66,7 +66,7 @@
     	moment.locale('@Culture');
 		ko.punches.enableAll();
 
-    	var rules = @ToJS(Model, true, true);
+		var rules = @ToJS(Model, true);
 		var urlMapper = new app.UrlMapper('@RootPath');
 		var repo = new app.AdminRepository(urlMapper);
 

--- a/VocaDbWeb/Views/Admin/ManageIPRules.cshtml
+++ b/VocaDbWeb/Views/Admin/ManageIPRules.cshtml
@@ -66,7 +66,7 @@
     	moment.locale('@Culture');
 		ko.punches.enableAll();
 
-    	var rules = @ToJS(Model, true, true);
+		var rules = @ToJS(Model, true);
 		var urlMapper = new app.UrlMapper('@RootPath');
 		var repo = new app.AdminRepository(urlMapper);
 


### PR DESCRIPTION
`JSON.parse` cannot parse `new Date()` and throws an `Uncaught SyntaxError`. I don't see any reason to set the third argument of `ToJS` to true.