### PR TITLE
Install HtmlSanitizer

### DIFF
--- a/VocaDbModel/DataContracts/Security/AuditLogEntryContract.cs
+++ b/VocaDbModel/DataContracts/Security/AuditLogEntryContract.cs
@@ -1,6 +1,7 @@
 #nullable disable
 
 using System;
+using Ganss.XSS;
 using VocaDb.Model.DataContracts.Users;
 using VocaDb.Model.Domain.Security;
 
@@ -14,7 +15,7 @@ namespace VocaDb.Model.DataContracts.Security
 		{
 			ParamIs.NotNull(() => entry);
 
-			Action = entry.Action;
+			Action = new HtmlSanitizer().Sanitize(entry.Action);
 			AgentName = entry.AgentName;
 			Id = entry.Id;
 			Time = entry.Time;

--- a/VocaDbModel/VocaDb.Model.csproj
+++ b/VocaDbModel/VocaDb.Model.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Antlr3.Runtime" Version="3.5.1" />
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="HtmlAgilityPack" Version="1.9.2" />
+    <PackageReference Include="HtmlSanitizer" Version="5.0.376" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />
     <PackageReference Include="IvanAkcheurov.NTextCat.Lib" Version="0.2.1.1" />
     <PackageReference Include="Microsoft.Bcl.Immutable" Version="1.0.34" />
@@ -59,7 +60,7 @@
     <PackageReference Include="System.IO.Packaging" Version="4.7.0" />
     <PackageReference Include="System.Runtime.Caching" Version="4.7.0" />
     <PackageReference Include="taglib" Version="2.1.0.0" />
-    <PackageReference Include="VocaDb.BandcampMetadataExtractor" Version="1.0.1" />
+    <PackageReference Include="VocaDb.BandcampMetadataExtractor" Version="1.0.2" />
     <PackageReference Include="VocaDb.NicoApiClient" Version="2.0.1" />
     <PackageReference Include="VocaDb.PiaproClient" Version="3.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Thanks to @Shiroizu. The problem here is that audit logs are rendered as raw HTML and they are not encoded by `HttpUtility.HtmlEncode(message)`. Should we remove external links as well?