### PR TITLE
#602 Text color has low contrast on Dark Angel theme

### DIFF
--- a/VocaDbWeb/wwwroot/Content/Styles/DarkAngel.less
+++ b/VocaDbWeb/wwwroot/Content/Styles/DarkAngel.less
@@ -1,4 +1,4 @@
-﻿@light-green: rgb(150, 220, 220);
+@light-green: rgb(150, 220, 220);
 @medium-green: #64B7B7;
 
 body {
@@ -41,7 +41,7 @@ body {
 }
 
 .rightFrame td {
-	color: #96dcdc;
+	color: #00c7c7;
 }
 
 .rightFrame .ui-widget-header a,
@@ -91,4 +91,8 @@ select, textarea, input[type="text"], input[type="password"], input[type="dateti
 
 .nav-list > li > a, .nav-list .nav-header {
 	text-shadow: none;
+}
+
+img[title="GitHub"] {
+	filter: invert(1);
 }


### PR DESCRIPTION
Closes #602. I also added an invert filter to the GitHub icon:
![image](https://user-images.githubusercontent.com/65015656/109284244-eff40c80-781f-11eb-8526-a0be0de6bd0b.png)
^Before

![image](https://user-images.githubusercontent.com/65015656/109284345-0ac68100-7820-11eb-9cea-f2fd4348eb24.png)
^After