### PR TITLE
New Artist Type DJ and Artist Role original performer

### DIFF
--- a/VocaDbModel/Domain/Artists/ArtistRoles.cs
+++ b/VocaDbModel/Domain/Artists/ArtistRoles.cs
@@ -73,5 +73,7 @@ namespace VocaDb.Model.Domain.Artists
 		Encoder = 1 << 14,
 
 		VocalDataProvider = 1 << 15,
+
+		OriginalPerformer = 1 << 16,
 	}
 }

--- a/VocaDbModel/Domain/Artists/ArtistType.cs
+++ b/VocaDbModel/Domain/Artists/ArtistType.cs
@@ -59,6 +59,8 @@ namespace VocaDb.Model.Domain.Artists
 		Character,
 
 		SynthesizerV,
+
+		DJ,
 	}
 
 	/// <summary>
@@ -105,5 +107,7 @@ namespace VocaDb.Model.Domain.Artists
 		Character = 1 << 16,
 
 		SynthesizerV = 1 << 17,
+
+		DJ = 1 << 18,
 	}
 }

--- a/VocaDbModel/Helpers/ArtistHelper.cs
+++ b/VocaDbModel/Helpers/ArtistHelper.cs
@@ -67,6 +67,7 @@ namespace VocaDb.Model.Helpers
 			{ ArtistType.Vocaloid, ArtistCategories.Vocalist },
 			{ ArtistType.Vocalist, ArtistCategories.Vocalist },
 			{ ArtistType.SynthesizerV, ArtistCategories.Vocalist },
+			{ ArtistType.DJ, ArtistCategories.Producer},
 		};
 
 		/// <summary>
@@ -76,7 +77,7 @@ namespace VocaDb.Model.Helpers
 		{
 			ArtistType.Animator, ArtistType.OtherGroup, ArtistType.OtherIndividual,
 			ArtistType.OtherVocalist, ArtistType.Producer, ArtistType.Illustrator, ArtistType.Lyricist,
-			ArtistType.Utaite, ArtistType.Band, ArtistType.Vocalist, ArtistType.Unknown
+			ArtistType.Utaite, ArtistType.Band, ArtistType.Vocalist, ArtistType.Unknown, ArtistType.DJ,
 		};
 
 		public static readonly ArtistType[] GroupTypes =
@@ -103,7 +104,7 @@ namespace VocaDb.Model.Helpers
 			ArtistType.Unknown, ArtistType.OtherGroup, ArtistType.OtherVocalist,
 			ArtistType.Producer, ArtistType.UTAU, ArtistType.CeVIO, ArtistType.Vocaloid, ArtistType.Animator, ArtistType.Illustrator,
 			ArtistType.Lyricist, ArtistType.OtherIndividual, ArtistType.Character,
-			ArtistType.SynthesizerV,
+			ArtistType.SynthesizerV, ArtistType.DJ,
 		};
 
 		public static readonly ArtistType[] VocalistTypes =

--- a/VocaDbModel/Resources/ArtistTypeNames.resx
+++ b/VocaDbModel/Resources/ArtistTypeNames.resx
@@ -174,4 +174,7 @@
   <data name="SynthesizerV" xml:space="preserve">
     <value>Synthesizer V</value>
   </data>
+  <data name="DJ" xml:space="preserve">
+    <value>DJ</value>
+  </data>
 </root>

--- a/VocaDbModel/Utils/AppConfig.cs
+++ b/VocaDbModel/Utils/AppConfig.cs
@@ -35,7 +35,8 @@ namespace VocaDb.Model.Utils
 			Domain.Artists.ArtistRoles.Vocalist,
 			Domain.Artists.ArtistRoles.VoiceManipulator,
 			Domain.Artists.ArtistRoles.VocalDataProvider,
-			Domain.Artists.ArtistRoles.Other
+			Domain.Artists.ArtistRoles.Other,
+			Domain.Artists.ArtistRoles.OriginalPerformer,
 		};
 
 		private static readonly DiscType[] DefaultDiscTypes = {

--- a/VocaDbWeb.Resources/App_GlobalResources/ArtistRoleNames.resx
+++ b/VocaDbWeb.Resources/App_GlobalResources/ArtistRoleNames.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -152,6 +152,9 @@
   </data>
   <data name="Mixer" xml:space="preserve">
     <value>Mixer</value>
+  </data>
+  <data name="OriginalPerformer" xml:space="preserve">
+    <value>Original performer</value>
   </data>
   <data name="Other" xml:space="preserve">
     <value>Other</value>

--- a/VocaDbWeb/wwwroot/Scripts/Helpers/ArtistHelper.ts
+++ b/VocaDbWeb/wwwroot/Scripts/Helpers/ArtistHelper.ts
@@ -12,7 +12,7 @@ import ContentFocus from '../Models/ContentFocus';
 		public static customizableTypes = [
 			ArtistType.Animator, ArtistType.OtherGroup, ArtistType.OtherIndividual, 
 			ArtistType.OtherVocalist, ArtistType.Producer, ArtistType.Illustrator, ArtistType.Lyricist, 
-			ArtistType.Utaite, ArtistType.Band, ArtistType.Vocalist, ArtistType.Unknown,
+			ArtistType.Utaite, ArtistType.Band, ArtistType.Vocalist, ArtistType.Unknown, ArtistType.DJ,
 		];
 
 		// Artist types that are groups (excluding Unknown)
@@ -103,6 +103,7 @@ import ContentFocus from '../Models/ContentFocus';
 			return (artistType === ArtistType.Producer
 				|| artistType === ArtistType.Circle
 				|| artistType === ArtistType.Band
+				|| artistType === ArtistType.DJ
 				|| (artistType === ArtistType.Animator && focus === ContentFocus.Video)
 				|| (artistType === ArtistType.Illustrator && focus === ContentFocus.Illustration));
 

--- a/VocaDbWeb/wwwroot/Scripts/Models/Artists/ArtistRoles.ts
+++ b/VocaDbWeb/wwwroot/Scripts/Models/Artists/ArtistRoles.ts
@@ -61,8 +61,9 @@
 		/// </summary>
 		Encoder				= 16384,
 
-		VocalDataProvider	= 32768
+		VocalDataProvider	= 32768,
 
+		OriginalPerformer	= 65536,
 	}
 
 	export default ArtistRoles;

--- a/VocaDbWeb/wwwroot/Scripts/Models/Artists/ArtistType.ts
+++ b/VocaDbWeb/wwwroot/Scripts/Models/Artists/ArtistType.ts
@@ -48,6 +48,8 @@
 
 		SynthesizerV,
 
+		DJ,
+
 	}
 
 	export default ArtistType;


### PR DESCRIPTION
Closes #319 and #299.

**DJ**
-> ArtistCategory Producer to avoid the need of role specification in remixes
-> Customizable to allow the role of mixer in Producer DJ collabs

**Original performer**
-> Example. [Kyary Pamyu Pamyu](https://vocadb.net/T/3234/kyary-pamyu-pamyu)

VocaDb wiki needs to be updated:
[Artist Types](https://wiki.vocadb.net/SiteSettings/Wiki/Index/23?title=Artist-types)
[Artist Roles](https://wiki.vocadb.net/SiteSettings/Wiki/Index/21?title=Artist-roles)