### PR TITLE
Increase the amount of visible events

### DIFF
--- a/VocaDbModel/Service/OtherService.cs
+++ b/VocaDbModel/Service/OtherService.cs
@@ -149,7 +149,7 @@ namespace VocaDb.Model.Service
 
 		private ReleaseEventForApiContract[] GetRecentEvents(ISession session)
 		{
-			var count = 3;
+			var count = 4;
 			var cacheKey = $"OtherService.RecentEvents.{LanguagePreference}";
 			return _cache.GetOrInsert(cacheKey, CachePolicy.AbsoluteExpiration(24), () =>
 			{

--- a/VocaDbWeb/Views/Shared/Partials/Shared/_EventThumbs.cshtml
+++ b/VocaDbWeb/Views/Shared/Partials/Shared/_EventThumbs.cshtml
@@ -24,6 +24,7 @@
 				<a href="@Url.EntryDetails(ev, ev.UrlSlug)" title="@ev.AdditionalNames">
 					@ev.Name
 				</a>
+				<br />
 				@if (cat != EventCategory.Unspecified && cat != EventCategory.Other)
 				{
 					@:(@Translate.ReleaseEventCategoryNames[cat])

--- a/VocaDbWeb/wwwroot/Content/Styles/base.less
+++ b/VocaDbWeb/wwwroot/Content/Styles/base.less
@@ -299,7 +299,7 @@ body .container-fluid {
 
 // Views
 .event-teaser, .event-teaser-tiny {
-	width: 29%;
+	width: 21%;
 	margin-right: 1%;
 	float: left;
 


### PR DESCRIPTION
Closes #849
I reduced the width of `.event-teaser` to keep events in one row. More events could cause bad line wrapping so everything beyond 4 needs a new row (Maybe implement that as an option with #95 ).