### PR TITLE
Artist url parser for twitter

### DIFF
--- a/Tests/Service/Helpers/ArtistExternalUrlParserTests.cs
+++ b/Tests/Service/Helpers/ArtistExternalUrlParserTests.cs
@@ -67,7 +67,7 @@ namespace VocaDb.Tests.Service.Helpers
 		[TestMethod]
 		public void Twitter_Shortcut()
 		{
-			TestGetExternalUrl("http://twitter.com/cleantears", "t/cleantears");
+			TestGetExternalUrl("t/cleantears", "http://twitter.com/cleantears");
 		}
 
 		[TestMethod]

--- a/Tests/Service/Helpers/ArtistExternalUrlParserTests.cs
+++ b/Tests/Service/Helpers/ArtistExternalUrlParserTests.cs
@@ -67,7 +67,7 @@ namespace VocaDb.Tests.Service.Helpers
 		[TestMethod]
 		public void Twitter_Shortcut()
 		{
-			TestGetExternalUrl("t/cleantears", "http://twitter.com/cleantears");
+			TestGetExternalUrl("t/cleantears", "https://twitter.com/cleantears");
 		}
 
 		[TestMethod]

--- a/Tests/Service/Helpers/ArtistExternalUrlParserTests.cs
+++ b/Tests/Service/Helpers/ArtistExternalUrlParserTests.cs
@@ -63,6 +63,12 @@ namespace VocaDb.Tests.Service.Helpers
 		{
 			TestGetExternalUrl("http://twitter.com/cleantears", "https://twitter.com/cleantears");
 		}
+		
+		[TestMethod]
+		public void Twitter_Shortcut()
+		{
+			TestGetExternalUrl("http://twitter.com/cleantears", "t/cleantears");
+		}
 
 		[TestMethod]
 		public void Piapro()

--- a/Tests/Service/Search/Artists/ArtistSearchTests.cs
+++ b/Tests/Service/Search/Artists/ArtistSearchTests.cs
@@ -59,6 +59,20 @@ namespace VocaDb.Tests.Service.Search.Artists
 			result.Items.Length.Should().Be(1, "Got 1 result");
 			result.Items[0].DefaultName.Should().Be("XenonP", "Result as expected");
 		}
+		
+		[TestMethod]
+		public void Find_ByTwitter_WithShortcut()
+		{
+			var result = _artistSearch.Find(new ArtistQueryParams
+			{
+				Common = {
+					TextQuery = ArtistSearchTextQuery.Create("t/XenonP_XM")
+				}
+			});
+
+			result.Items.Length.Should().Be(1, "Got 1 result");
+			result.Items[0].DefaultName.Should().Be("XenonP", "Result as expected");
+		}
 
 		[TestMethod]
 		public void Find_ByTwitter_EndsWithP()

--- a/VocaDbModel/Service/Helpers/ArtistExternalUrlParser.cs
+++ b/VocaDbModel/Service/Helpers/ArtistExternalUrlParser.cs
@@ -14,7 +14,7 @@ namespace VocaDb.Model.Service.Helpers
 	{
 		private static readonly RegexLinkMatcher[] linkMatchers = {
 			new RegexLinkMatcher("https://www.nicovideo.jp/{0}/{1}", @"^(?:http(?:s)?://www.nicovideo.jp)?/?(user|mylist)/(\d+)"),
-			new RegexLinkMatcher("https://twitter.com/{0}", @"^http(?:s)?://twitter\.com/(\w+)")
+			new RegexLinkMatcher("https://twitter.com/{0}", @"^(?:http(?:s)?://twitter\.com|t)/(\w+)")
 		};
 
 		private static readonly string[] whitelistedUrls = {

--- a/VocaDbModel/Service/Helpers/ArtistExternalUrlParser.cs
+++ b/VocaDbModel/Service/Helpers/ArtistExternalUrlParser.cs
@@ -14,6 +14,7 @@ namespace VocaDb.Model.Service.Helpers
 	{
 		private static readonly RegexLinkMatcher[] linkMatchers = {
 			new RegexLinkMatcher("https://www.nicovideo.jp/{0}/{1}", @"^(?:http(?:s)?://www.nicovideo.jp)?/?(user|mylist)/(\d+)"),
+			// `twitter.com/name` or `t/name`.
 			new RegexLinkMatcher("https://twitter.com/{0}", @"^(?:http(?:s)?://twitter\.com|t)/(\w+)")
 		};
 

--- a/VocaDbModel/Service/Search/Artists/ArtistSearch.cs
+++ b/VocaDbModel/Service/Search/Artists/ArtistSearch.cs
@@ -56,7 +56,7 @@ namespace VocaDb.Model.Service.Search.Artists
 
 		private ParsedArtistQuery FindExternalUrl(string trimmed, string trimmedLc)
 		{
-			if (trimmedLc.StartsWith("http") || trimmedLc.StartsWith("mylist/") || trimmedLc.StartsWith("user/"))
+			if (trimmedLc.StartsWith("http") || trimmedLc.StartsWith("mylist/") || trimmedLc.StartsWith("user/") || trimmedLc.StartsWith("t/"))
 			{
 				var extUrl = new ArtistExternalUrlParser().GetExternalUrl(trimmed);
 


### PR DESCRIPTION
Closes #843.
I changed the suggested URL parser from `@{Twitter username}` to `t/{Twitter username}` because there are some artists who use @ at the beginning of their username (https://vocadb.net/Search?filter=@*&searchType=Artist). Perhaps more such specific website shortcuts could be implemented (e.g. p/ for piapro). 