### PR TITLE
Add SongList to TagTargetTypes

### DIFF
--- a/Tests/Domain/Tags/TagTargetTypesTests.cs
+++ b/Tests/Domain/Tags/TagTargetTypesTests.cs
@@ -15,6 +15,7 @@ namespace VocaDb.Tests.Domain.Tags
 		[DataRow(1 | 64, TagTargetTypes.AlbumSong)]
 		[DataRow(2 | 64, TagTargetTypes.ArtistSong)]
 		[DataRow(16, TagTargetTypes.Event)]
+		[DataRow(128, TagTargetTypes.SongList)]
 		[DataRow(1073741823, TagTargetTypes.All)]
 		[TestMethod]
 		public void Value(int expected, TagTargetTypes actual)

--- a/VocaDbModel/Domain/Tags/TagTargetTypes.cs
+++ b/VocaDbModel/Domain/Tags/TagTargetTypes.cs
@@ -34,6 +34,7 @@ namespace VocaDb.Model.Domain.Tags
 		/// </summary>
 		ArtistSong = Artist | Song,
 		Event = EntryType.ReleaseEvent,
+		SongList = EntryType.SongList,
 		/// <summary>
 		/// Valid for all entry types (default)
 		/// </summary>


### PR DESCRIPTION
Prevents TagApiController.GetList from throwing 400 Bad Request.