### PR TITLE
Feat/163 update URL on search page

### DIFF
--- a/VocaDbWeb/Scripts/Components/Discussion/DiscussionFolders.tsx
+++ b/VocaDbWeb/Scripts/Components/Discussion/DiscussionFolders.tsx
@@ -1,4 +1,5 @@
 import Breadcrumb from '@Bootstrap/Breadcrumb';
+import useStoreWithPaging from '@Components/useStoreWithPaging';
 import DiscussionIndexStore from '@Stores/Discussion/DiscussionIndexStore';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
@@ -8,6 +9,22 @@ import { Link, useParams } from 'react-router-dom';
 import { DiscussionLayout } from './DiscussionRoutes';
 import ViewFolder from './Partials/ViewFolder';
 
+const useDiscussionIndexStore = (
+	discussionIndexStore: DiscussionIndexStore,
+): void => {
+	const { folderId } = useParams();
+
+	React.useEffect(() => {
+		discussionIndexStore.selectFolderById(Number(folderId));
+	}, [discussionIndexStore, discussionIndexStore.folders, folderId]);
+
+	useStoreWithPaging(discussionIndexStore);
+
+	React.useEffect(() => {
+		discussionIndexStore.updateResults(true);
+	}, [discussionIndexStore, discussionIndexStore.folders, folderId]);
+};
+
 interface DiscussionFoldersProps {
 	discussionIndexStore: DiscussionIndexStore;
 }
@@ -15,11 +32,8 @@ interface DiscussionFoldersProps {
 const DiscussionFolders = observer(
 	({ discussionIndexStore }: DiscussionFoldersProps): React.ReactElement => {
 		const { t } = useTranslation(['ViewRes.Discussion']);
-		const { folderId } = useParams();
 
-		React.useEffect(() => {
-			discussionIndexStore.selectFolderById(Number(folderId));
-		}, [discussionIndexStore, folderId]);
+		useDiscussionIndexStore(discussionIndexStore);
 
 		return (
 			<DiscussionLayout>

--- a/VocaDbWeb/Scripts/Components/Discussion/Partials/ViewTopic.tsx
+++ b/VocaDbWeb/Scripts/Components/Discussion/Partials/ViewTopic.tsx
@@ -2,6 +2,7 @@ import Alert from '@Bootstrap/Alert';
 import Button from '@Bootstrap/Button';
 import CommentKnockout from '@Components/Shared/Partials/Comment/CommentKnockout';
 import EditableComments from '@Components/Shared/Partials/Comment/EditableComments';
+import useStoreWithRouteParams from '@Components/useStoreWithRouteParams';
 import LoginManager from '@Models/LoginManager';
 import DiscussionIndexStore from '@Stores/Discussion/DiscussionIndexStore';
 import DiscussionTopicStore from '@Stores/Discussion/DiscussionTopicStore';
@@ -26,6 +27,8 @@ const ViewTopic = observer(
 	}: ViewTopicProps): React.ReactElement => {
 		const { t } = useTranslation(['ViewRes']);
 		const navigate = useNavigate();
+
+		useStoreWithRouteParams(discussionTopicStore);
 
 		return (
 			<div>

--- a/VocaDbWeb/Scripts/Components/Search/SearchIndex.tsx
+++ b/VocaDbWeb/Scripts/Components/Search/SearchIndex.tsx
@@ -10,8 +10,7 @@ import {
 } from '@Components/Shared/Partials/Knockout/SearchDropdown';
 import TagFilters from '@Components/Shared/Partials/Knockout/TagFilters';
 import useScript from '@Components/useScript';
-import useStoreWithRouteParams from '@Components/useStoreWithRouteParams';
-import useStoreWithUpdateResults from '@Components/useStoreWithUpdateResults';
+import useStoreWithPaging from '@Components/useStoreWithPaging';
 import AlbumRepository from '@Repositories/AlbumRepository';
 import ArtistRepository from '@Repositories/ArtistRepository';
 import EntryRepository from '@Repositories/EntryRepository';
@@ -22,12 +21,7 @@ import UserRepository from '@Repositories/UserRepository';
 import HttpClient from '@Shared/HttpClient';
 import UrlMapper from '@Shared/UrlMapper';
 import PVPlayersFactory from '@Stores/PVs/PVPlayersFactory';
-import SearchStore, {
-	SearchRouteParams,
-	SearchType,
-} from '@Stores/Search/SearchStore';
-import Ajv, { JSONSchemaType } from 'ajv';
-import addFormats from 'ajv-formats';
+import SearchStore, { SearchType } from '@Stores/Search/SearchStore';
 import classNames from 'classnames';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
@@ -98,14 +92,6 @@ const SearchCategory = observer(
 	},
 );
 
-// TODO: Use single Ajv instance. See https://ajv.js.org/guide/managing-schemas.html.
-const ajv = new Ajv({ coerceTypes: true });
-addFormats(ajv);
-
-// TODO: Make sure that we compile schemas only once and re-use compiled validation functions. See https://ajv.js.org/guide/getting-started.html.
-const schema: JSONSchemaType<SearchRouteParams> = require('@Stores/Search/SearchRouteParams.schema');
-const validate = ajv.compile(schema);
-
 const SearchIndex = observer(
 	(): React.ReactElement => {
 		const { t } = useTranslation([
@@ -114,14 +100,7 @@ const SearchIndex = observer(
 			'VocaDb.Web.Resources.Domain',
 		]);
 
-		const { popState } = useStoreWithRouteParams(validate, searchStore);
-
-		useStoreWithUpdateResults(
-			searchStore,
-			React.useCallback(() => {
-				if (!popState.current) searchStore.paging.goToFirstPage();
-			}, [popState]),
-		);
+		useStoreWithPaging(searchStore);
 
 		useScript('/Scripts/soundcloud-api.js');
 		useScript('https://www.youtube.com/iframe_api');

--- a/VocaDbWeb/Scripts/Components/Search/SearchIndex.tsx
+++ b/VocaDbWeb/Scripts/Components/Search/SearchIndex.tsx
@@ -114,9 +114,14 @@ const SearchIndex = observer(
 			'VocaDb.Web.Resources.Domain',
 		]);
 
-		useStoreWithRouteParams(validate, searchStore);
+		const { popState } = useStoreWithRouteParams(validate, searchStore);
 
-		useStoreWithUpdateResults(searchStore);
+		useStoreWithUpdateResults(
+			searchStore,
+			React.useCallback(() => {
+				if (!popState.current) searchStore.paging.goToFirstPage();
+			}, [popState]),
+		);
 
 		useScript('/Scripts/soundcloud-api.js');
 		useScript('https://www.youtube.com/iframe_api');

--- a/VocaDbWeb/Scripts/Components/Search/SearchIndex.tsx
+++ b/VocaDbWeb/Scripts/Components/Search/SearchIndex.tsx
@@ -11,6 +11,7 @@ import {
 import TagFilters from '@Components/Shared/Partials/Knockout/TagFilters';
 import useScript from '@Components/useScript';
 import useStoreWithRouteParams from '@Components/useStoreWithRouteParams';
+import useStoreWithUpdateResults from '@Components/useStoreWithUpdateResults';
 import AlbumRepository from '@Repositories/AlbumRepository';
 import ArtistRepository from '@Repositories/ArtistRepository';
 import EntryRepository from '@Repositories/EntryRepository';
@@ -115,9 +116,7 @@ const SearchIndex = observer(
 
 		useStoreWithRouteParams(validate, searchStore);
 
-		React.useEffect(() => {
-			searchStore.updateResults();
-		}, []);
+		useStoreWithUpdateResults(searchStore);
 
 		useScript('/Scripts/soundcloud-api.js');
 		useScript('https://www.youtube.com/iframe_api');

--- a/VocaDbWeb/Scripts/Components/Shared/Partials/Knockout/LockingAutoComplete.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/Partials/Knockout/LockingAutoComplete.tsx
@@ -33,7 +33,12 @@ const LockingAutoComplete = React.memo(
 						<i className="icon icon-info-sign" />
 					</Button>
 				)}
-				<input type="text" className="input-large" readOnly value={text} />
+				<input
+					type="text"
+					className="input-large"
+					readOnly
+					value={text ?? ''}
+				/>
 				<Button variant="danger" onClick={onClear}>
 					{t('ViewRes:Shared.Clear')}
 				</Button>

--- a/VocaDbWeb/Scripts/Components/Shared/Partials/Knockout/ReleaseEventLockingAutoComplete.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/Partials/Knockout/ReleaseEventLockingAutoComplete.tsx
@@ -1,7 +1,6 @@
 import ReleaseEventAutoComplete from '@Components/KnockoutExtensions/ReleaseEventAutoComplete';
 import IEntryWithIdAndName from '@Models/IEntryWithIdAndName';
 import BasicEntryLinkStore from '@Stores/BasicEntryLinkStore';
-import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,19 +21,13 @@ const ReleaseEventLockingAutoComplete = observer(
 			<LockingAutoComplete
 				text={basicEntryLinkStore.name}
 				value={basicEntryLinkStore.id}
-				onClear={(): void =>
-					runInAction(() => {
-						basicEntryLinkStore.entry = undefined;
-					})
-				}
+				onClear={(): void => basicEntryLinkStore.selectEntry(undefined)}
 			>
 				<ReleaseEventAutoComplete
 					type="text"
 					className="input-large"
 					onAcceptSelection={(entry): void =>
-						runInAction(() => {
-							basicEntryLinkStore.entry = entry;
-						})
+						basicEntryLinkStore.selectEntry(entry.id)
 					}
 					placeholder={t('ViewRes:Shared.Search')}
 				/>

--- a/VocaDbWeb/Scripts/Components/Shared/Partials/Knockout/SongLockingAutoComplete.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/Partials/Knockout/SongLockingAutoComplete.tsx
@@ -2,7 +2,6 @@ import SongAutoComplete from '@Components/KnockoutExtensions/SongAutoComplete';
 import SongContract from '@DataContracts/Song/SongContract';
 import EntryType from '@Models/EntryType';
 import BasicEntryLinkStore from '@Stores/BasicEntryLinkStore';
-import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -29,20 +28,13 @@ const SongLockingAutoComplete = observer(
 				text={basicEntryLinkStore.name}
 				value={basicEntryLinkStore.id}
 				entryType={EntryType.Song}
-				onClear={(): void =>
-					runInAction(() => {
-						basicEntryLinkStore.entry = undefined;
-					})
-				}
+				onClear={(): void => basicEntryLinkStore.selectEntry(undefined)}
 			>
 				<SongAutoComplete
 					type="text"
 					className="input-large"
 					properties={{
-						acceptSelection: (id): void =>
-							runInAction(() => {
-								basicEntryLinkStore.id = id;
-							}),
+						acceptSelection: (id): void => basicEntryLinkStore.selectEntry(id),
 						extraQueryParams: { songTypes: songTypes.join(',') },
 						ignoreId: ignoreId,
 					}}

--- a/VocaDbWeb/Scripts/Components/Shared/Partials/TagFilters.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/Partials/TagFilters.tsx
@@ -29,7 +29,7 @@ const TagFilters = observer(
 									type="text"
 									className="input-large"
 									readOnly
-									value={tag.name}
+									value={tag.name ?? ''}
 								/>
 								<Button
 									variant="danger"

--- a/VocaDbWeb/Scripts/Components/SongList/SongListFeatured.tsx
+++ b/VocaDbWeb/Scripts/Components/SongList/SongListFeatured.tsx
@@ -2,6 +2,7 @@ import SafeAnchor from '@Bootstrap/SafeAnchor';
 import Layout from '@Components/Shared/Layout';
 import SongListsKnockout from '@Components/Shared/Partials/Song/SongListsKnockout';
 import SongListsFilters from '@Components/Shared/Partials/SongListsFilters';
+import useStoreWithUpdateResults from '@Components/useStoreWithUpdateResults';
 import JQueryUIButton from '@JQueryUI/JQueryUIButton';
 import LoginManager from '@Models/LoginManager';
 import SongListRepository from '@Repositories/SongListRepository';
@@ -43,13 +44,7 @@ const SongListFeatured = observer(
 			'ViewRes.User',
 		]);
 
-		React.useEffect(() => {
-			Object.values(SongListFeaturedCategory)
-				.filter((category) => category !== SongListFeaturedCategory.Nothing)
-				.forEach((category) => {
-					featuredSongListsStore.categories[category].clear();
-				});
-		}, []);
+		useStoreWithUpdateResults(featuredSongListsStore);
 
 		return (
 			<Layout

--- a/VocaDbWeb/Scripts/Components/User/UserIndex.tsx
+++ b/VocaDbWeb/Scripts/Components/User/UserIndex.tsx
@@ -1,13 +1,9 @@
 import Layout from '@Components/Shared/Layout';
-import useStoreWithRouteParams from '@Components/useStoreWithRouteParams';
-import useStoreWithUpdateResults from '@Components/useStoreWithUpdateResults';
+import useStoreWithPaging from '@Components/useStoreWithPaging';
 import UserRepository from '@Repositories/UserRepository';
 import HttpClient from '@Shared/HttpClient';
 import UrlMapper from '@Shared/UrlMapper';
-import ListUsersStore, {
-	ListUsersRouteParams,
-} from '@Stores/User/ListUsersStore';
-import Ajv, { JSONSchemaType } from 'ajv';
+import ListUsersStore from '@Stores/User/ListUsersStore';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -18,24 +14,10 @@ const urlMapper = new UrlMapper(vdb.values.baseAddress);
 const userRepo = new UserRepository(httpClient, urlMapper);
 const listUsersStore = new ListUsersStore(userRepo);
 
-// TODO: Use single Ajv instance. See https://ajv.js.org/guide/managing-schemas.html.
-const ajv = new Ajv({ coerceTypes: true });
-
-// TODO: Make sure that we compile schemas only once and re-use compiled validation functions. See https://ajv.js.org/guide/getting-started.html.
-const schema: JSONSchemaType<ListUsersRouteParams> = require('@Stores/User/ListUsersRouteParams.schema');
-const validate = ajv.compile(schema);
-
 const UserIndex = (): React.ReactElement => {
 	const { t } = useTranslation(['ViewRes']);
 
-	const { popState } = useStoreWithRouteParams(validate, listUsersStore);
-
-	useStoreWithUpdateResults(
-		listUsersStore,
-		React.useCallback(() => {
-			if (!popState.current) listUsersStore.paging.goToFirstPage();
-		}, [popState]),
-	);
+	useStoreWithPaging(listUsersStore);
 
 	return (
 		<Layout title={t('ViewRes:Shared.Users')}>

--- a/VocaDbWeb/Scripts/Components/User/UserIndex.tsx
+++ b/VocaDbWeb/Scripts/Components/User/UserIndex.tsx
@@ -1,9 +1,12 @@
 import Layout from '@Components/Shared/Layout';
-import UserGroup from '@Models/Users/UserGroup';
+import useStoreWithRouteParams from '@Components/useStoreWithRouteParams';
 import UserRepository from '@Repositories/UserRepository';
 import HttpClient from '@Shared/HttpClient';
 import UrlMapper from '@Shared/UrlMapper';
-import ListUsersStore from '@Stores/User/ListUsersStore';
+import ListUsersStore, {
+	ListUsersRouteParams,
+} from '@Stores/User/ListUsersStore';
+import Ajv, { JSONSchemaType } from 'ajv';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -14,15 +17,17 @@ const urlMapper = new UrlMapper(vdb.values.baseAddress);
 const userRepo = new UserRepository(httpClient, urlMapper);
 const listUsersStore = new ListUsersStore(userRepo);
 
-// TODO: use this
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-interface UserIndexQueryParams {
-	filter?: string;
-	groupId?: UserGroup;
-}
+// TODO: Use single Ajv instance. See https://ajv.js.org/guide/managing-schemas.html.
+const ajv = new Ajv({ coerceTypes: true });
+
+// TODO: Make sure that we compile schemas only once and re-use compiled validation functions. See https://ajv.js.org/guide/getting-started.html.
+const schema: JSONSchemaType<ListUsersRouteParams> = require('@Stores/User/ListUsersRouteParams.schema');
+const validate = ajv.compile(schema);
 
 const UserIndex = (): React.ReactElement => {
 	const { t } = useTranslation(['ViewRes']);
+
+	useStoreWithRouteParams(validate, listUsersStore);
 
 	return (
 		<Layout title={t('ViewRes:Shared.Users')}>

--- a/VocaDbWeb/Scripts/Components/User/UserIndex.tsx
+++ b/VocaDbWeb/Scripts/Components/User/UserIndex.tsx
@@ -28,9 +28,14 @@ const validate = ajv.compile(schema);
 const UserIndex = (): React.ReactElement => {
 	const { t } = useTranslation(['ViewRes']);
 
-	useStoreWithRouteParams(validate, listUsersStore);
+	const { popState } = useStoreWithRouteParams(validate, listUsersStore);
 
-	useStoreWithUpdateResults(listUsersStore);
+	useStoreWithUpdateResults(
+		listUsersStore,
+		React.useCallback(() => {
+			if (!popState.current) listUsersStore.paging.goToFirstPage();
+		}, [popState]),
+	);
 
 	return (
 		<Layout title={t('ViewRes:Shared.Users')}>

--- a/VocaDbWeb/Scripts/Components/User/UserIndex.tsx
+++ b/VocaDbWeb/Scripts/Components/User/UserIndex.tsx
@@ -1,5 +1,6 @@
 import Layout from '@Components/Shared/Layout';
 import useStoreWithRouteParams from '@Components/useStoreWithRouteParams';
+import useStoreWithUpdateResults from '@Components/useStoreWithUpdateResults';
 import UserRepository from '@Repositories/UserRepository';
 import HttpClient from '@Shared/HttpClient';
 import UrlMapper from '@Shared/UrlMapper';
@@ -28,6 +29,8 @@ const UserIndex = (): React.ReactElement => {
 	const { t } = useTranslation(['ViewRes']);
 
 	useStoreWithRouteParams(validate, listUsersStore);
+
+	useStoreWithUpdateResults(listUsersStore);
 
 	return (
 		<Layout title={t('ViewRes:Shared.Users')}>

--- a/VocaDbWeb/Scripts/Components/useStoreWithPaging.ts
+++ b/VocaDbWeb/Scripts/Components/useStoreWithPaging.ts
@@ -17,6 +17,11 @@ const useStoreWithPaging = <T>(store: IStoreWithPaging<T>): void => {
 	useStoreWithUpdateResults(store, handleClearResults);
 
 	useStoreWithRouteParams(store);
+
+	React.useEffect(() => {
+		// This is called when the page is first loaded.
+		store.updateResults(true);
+	}, [store]);
 };
 
 export default useStoreWithPaging;

--- a/VocaDbWeb/Scripts/Components/useStoreWithPaging.ts
+++ b/VocaDbWeb/Scripts/Components/useStoreWithPaging.ts
@@ -1,0 +1,22 @@
+import IStoreWithPaging from '@Stores/IStoreWithPaging';
+import React from 'react';
+
+import useStoreWithRouteParams from './useStoreWithRouteParams';
+import useStoreWithUpdateResults from './useStoreWithUpdateResults';
+
+const useStoreWithPaging = <T>(store: IStoreWithPaging<T>): void => {
+	const handleClearResults = React.useCallback(
+		(popState) => {
+			// Do not go to the first page when the back/forward buttons are clicked.
+			if (!popState) store.paging.goToFirstPage();
+		},
+		[store],
+	);
+
+	// `useStoreWithUpdateResults` must be called before `useStoreWithRouteParams` because the former may change `routeParams` based on `clearResultsByQueryKeys`.
+	useStoreWithUpdateResults(store, handleClearResults);
+
+	useStoreWithRouteParams(store);
+};
+
+export default useStoreWithPaging;

--- a/VocaDbWeb/Scripts/Components/useStoreWithPaging.ts
+++ b/VocaDbWeb/Scripts/Components/useStoreWithPaging.ts
@@ -1,7 +1,6 @@
 import IStoreWithPaging from '@Stores/IStoreWithPaging';
 import React from 'react';
 
-import useStoreWithRouteParams from './useStoreWithRouteParams';
 import useStoreWithUpdateResults from './useStoreWithUpdateResults';
 
 const useStoreWithPaging = <T>(store: IStoreWithPaging<T>): void => {
@@ -15,13 +14,6 @@ const useStoreWithPaging = <T>(store: IStoreWithPaging<T>): void => {
 
 	// `useStoreWithUpdateResults` must be called before `useStoreWithRouteParams` because the former may change `routeParams` based on `clearResultsByQueryKeys`.
 	useStoreWithUpdateResults(store, handleClearResults);
-
-	useStoreWithRouteParams(store);
-
-	React.useEffect(() => {
-		// This is called when the page is first loaded.
-		store.updateResults(true);
-	}, [store]);
 };
 
 export default useStoreWithPaging;

--- a/VocaDbWeb/Scripts/Components/useStoreWithRouteParams.ts
+++ b/VocaDbWeb/Scripts/Components/useStoreWithRouteParams.ts
@@ -1,22 +1,46 @@
 import IStoreWithRouteParams from '@Stores/IStoreWithRouteParams';
 import { ValidateFunction } from 'ajv';
+import { reaction } from 'mobx';
 import qs from 'qs';
 import React from 'react';
-import { useLocation } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 
 const useStoreWithRouteParams = <T>(
 	validate: ValidateFunction<T>,
 	store: IStoreWithRouteParams<T>,
 ): void => {
+	// Whether currently processing popstate. This is to prevent adding the previous state to history.
+	const popState = React.useRef(false);
+
 	const location = useLocation();
 
+	// Pass `location` as deps instead of `location.search`.
 	React.useEffect(() => {
 		const routeParams: any = qs.parse(location.search.slice(1));
 
 		if (validate(routeParams)) {
+			popState.current = true;
+
 			store.routeParams = routeParams;
+
+			popState.current = false;
 		}
 	}, [location, validate, store]);
+
+	const navigate = useNavigate();
+
+	React.useEffect(() => {
+		// Returns the disposer.
+		return reaction(
+			() => store.routeParams,
+			(routeParams) => {
+				if (!popState.current) {
+					// TODO: is there any way to push changes to url without re-rendering?
+					navigate(`${location.pathname}?${qs.stringify(routeParams)}`);
+				}
+			},
+		);
+	}, [location.pathname, store, navigate]);
 };
 
 export default useStoreWithRouteParams;

--- a/VocaDbWeb/Scripts/Components/useStoreWithRouteParams.ts
+++ b/VocaDbWeb/Scripts/Components/useStoreWithRouteParams.ts
@@ -8,7 +8,7 @@ import { useLocation, useNavigate } from 'react-router';
 const useStoreWithRouteParams = <T>(
 	validate: ValidateFunction<T>,
 	store: IStoreWithRouteParams<T>,
-): void => {
+): { popState: React.MutableRefObject<boolean> } => {
 	// Whether currently processing popstate. This is to prevent adding the previous state to history.
 	const popState = React.useRef(false);
 
@@ -41,6 +41,8 @@ const useStoreWithRouteParams = <T>(
 			},
 		);
 	}, [location.pathname, store, navigate]);
+
+	return { popState: popState };
 };
 
 export default useStoreWithRouteParams;

--- a/VocaDbWeb/Scripts/Components/useStoreWithRouteParams.ts
+++ b/VocaDbWeb/Scripts/Components/useStoreWithRouteParams.ts
@@ -1,0 +1,22 @@
+import IStoreWithRouteParams from '@Stores/IStoreWithRouteParams';
+import { ValidateFunction } from 'ajv';
+import qs from 'qs';
+import React from 'react';
+import { useLocation } from 'react-router';
+
+const useStoreWithRouteParams = <T>(
+	validate: ValidateFunction<T>,
+	store: IStoreWithRouteParams<T>,
+): void => {
+	const location = useLocation();
+
+	React.useEffect(() => {
+		const routeParams: any = qs.parse(location.search.slice(1));
+
+		if (validate(routeParams)) {
+			store.routeParams = routeParams;
+		}
+	}, [location, validate, store]);
+};
+
+export default useStoreWithRouteParams;

--- a/VocaDbWeb/Scripts/Components/useStoreWithUpdateResults.ts
+++ b/VocaDbWeb/Scripts/Components/useStoreWithUpdateResults.ts
@@ -3,11 +3,13 @@ import _ from 'lodash';
 import { reaction } from 'mobx';
 import React from 'react';
 
+import useStoreWithRouteParams from './useStoreWithRouteParams';
+
 // Updates search results whenever the `routeParams` property changes.
 const useStoreWithUpdateResults = <T extends Object>(
 	store: IStoreWithUpdateResults<T>,
 	// Called when search results should be cleared.
-	onClearResults: (popState: boolean) => void,
+	onClearResults?: (popState: boolean) => void,
 ): void => {
 	React.useEffect(() => {
 		// Returns the disposer.
@@ -28,12 +30,19 @@ const useStoreWithUpdateResults = <T extends Object>(
 					.some((k) => store.clearResultsByQueryKeys.includes(k))
 					.value();
 
-				if (clearResults) onClearResults(store.popState);
+				if (clearResults) onClearResults?.(store.popState);
 
 				store.updateResults(clearResults);
 			},
 		);
 	}, [store, onClearResults]);
+
+	useStoreWithRouteParams(store);
+
+	React.useEffect(() => {
+		// This is called when the page is first loaded.
+		store.updateResults(true);
+	}, [store]);
 };
 
 export default useStoreWithUpdateResults;

--- a/VocaDbWeb/Scripts/Components/useStoreWithUpdateResults.ts
+++ b/VocaDbWeb/Scripts/Components/useStoreWithUpdateResults.ts
@@ -5,6 +5,7 @@ import React from 'react';
 
 const useStoreWithUpdateResults = <T extends Object>(
 	store: IStoreWithUpdateResults<T>,
+	onClearResults: () => void,
 ): void => {
 	React.useEffect(() => {
 		store.updateResults(true);
@@ -24,10 +25,12 @@ const useStoreWithUpdateResults = <T extends Object>(
 					.some((k) => store.clearResultsByQueryKeys.includes(k))
 					.value();
 
+				if (clearResults) onClearResults();
+
 				store.updateResults(clearResults);
 			},
 		);
-	}, [store]);
+	}, [store, onClearResults]);
 };
 
 export default useStoreWithUpdateResults;

--- a/VocaDbWeb/Scripts/Components/useStoreWithUpdateResults.ts
+++ b/VocaDbWeb/Scripts/Components/useStoreWithUpdateResults.ts
@@ -10,9 +10,6 @@ const useStoreWithUpdateResults = <T extends Object>(
 	onClearResults: (popState: boolean) => void,
 ): void => {
 	React.useEffect(() => {
-		// This is called when the page is first loaded.
-		store.updateResults(true);
-
 		// Returns the disposer.
 		return reaction(
 			() => store.routeParams,

--- a/VocaDbWeb/Scripts/Components/useStoreWithUpdateResults.ts
+++ b/VocaDbWeb/Scripts/Components/useStoreWithUpdateResults.ts
@@ -3,17 +3,23 @@ import _ from 'lodash';
 import { reaction } from 'mobx';
 import React from 'react';
 
+// Updates search results whenever the `routeParams` property changes.
 const useStoreWithUpdateResults = <T extends Object>(
 	store: IStoreWithUpdateResults<T>,
-	onClearResults: () => void,
+	// Called when search results should be cleared.
+	onClearResults: (popState: boolean) => void,
 ): void => {
 	React.useEffect(() => {
+		// This is called when the page is first loaded.
 		store.updateResults(true);
 
 		// Returns the disposer.
 		return reaction(
 			() => store.routeParams,
 			(routeParams, previousRouteParams) => {
+				// Determines if search results should be cleared by comparing the current and previous values.
+				// Assuming that the current value is `{ filter: 'Miku', page: 3939, searchType: 'Artist' }`, and the previous one is `{ filter: 'Miku', page: 1 }`,
+				// then the diff will be `{ page: 3939, searchType: 'Artist' }`, which results in `['page', 'searchType']`.
 				const clearResults = _.chain(routeParams)
 					.omitBy((v, k) =>
 						_.isEqual(
@@ -25,7 +31,7 @@ const useStoreWithUpdateResults = <T extends Object>(
 					.some((k) => store.clearResultsByQueryKeys.includes(k))
 					.value();
 
-				if (clearResults) onClearResults();
+				if (clearResults) onClearResults(store.popState);
 
 				store.updateResults(clearResults);
 			},

--- a/VocaDbWeb/Scripts/Components/useStoreWithUpdateResults.ts
+++ b/VocaDbWeb/Scripts/Components/useStoreWithUpdateResults.ts
@@ -1,0 +1,33 @@
+import IStoreWithUpdateResults from '@Stores/IStoreWithUpdateResults';
+import _ from 'lodash';
+import { reaction } from 'mobx';
+import React from 'react';
+
+const useStoreWithUpdateResults = <T extends Object>(
+	store: IStoreWithUpdateResults<T>,
+): void => {
+	React.useEffect(() => {
+		store.updateResults(true);
+
+		// Returns the disposer.
+		return reaction(
+			() => store.routeParams,
+			(routeParams, previousRouteParams) => {
+				const clearResults = _.chain(routeParams)
+					.omitBy((v, k) =>
+						_.isEqual(
+							previousRouteParams[k as keyof typeof previousRouteParams],
+							v,
+						),
+					)
+					.keys()
+					.some((k) => store.clearResultsByQueryKeys.includes(k))
+					.value();
+
+				store.updateResults(clearResults);
+			},
+		);
+	}, [store]);
+};
+
+export default useStoreWithUpdateResults;

--- a/VocaDbWeb/Scripts/Stores/Discussion/DiscussionIndexRouteParams.schema.json
+++ b/VocaDbWeb/Scripts/Stores/Discussion/DiscussionIndexRouteParams.schema.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"properties": {
+		"page": {
+			"type": "number"
+		}
+	},
+	"type": "object"
+}

--- a/VocaDbWeb/Scripts/Stores/Discussion/DiscussionIndexStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Discussion/DiscussionIndexStore.ts
@@ -39,7 +39,6 @@ export default class DiscussionIndexStore
 	@observable public selectedTopic?: DiscussionTopicStore = undefined;
 	@observable public showCreateNewTopic: boolean = false;
 	@observable public topics: DiscussionTopicContract[] = [];
-	private pauseNotifications = false;
 
 	public constructor(
 		public readonly loginManager: LoginManager,
@@ -188,6 +187,8 @@ export default class DiscussionIndexStore
 	public validateRouteParams = (
 		data: any,
 	): data is DiscussionIndexRouteParams => validate(data);
+
+	private pauseNotifications = false;
 
 	public updateResults = (clearResults: boolean): void => {
 		if (this.pauseNotifications) return;

--- a/VocaDbWeb/Scripts/Stores/Discussion/DiscussionIndexStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Discussion/DiscussionIndexStore.ts
@@ -2,10 +2,13 @@ import DiscussionFolderContract from '@DataContracts/Discussion/DiscussionFolder
 import DiscussionTopicContract from '@DataContracts/Discussion/DiscussionTopicContract';
 import LoginManager from '@Models/LoginManager';
 import DiscussionRepository from '@Repositories/DiscussionRepository';
+import IStoreWithPaging from '@Stores/IStoreWithPaging';
 import ServerSidePagingStore from '@Stores/ServerSidePagingStore';
+import Ajv, { JSONSchemaType } from 'ajv';
 import _ from 'lodash';
 import {
 	action,
+	computed,
 	makeObservable,
 	observable,
 	reaction,
@@ -15,7 +18,19 @@ import {
 import DiscussionTopicEditStore from './DiscussionTopicEditStore';
 import DiscussionTopicStore from './DiscussionTopicStore';
 
-export default class DiscussionIndexStore {
+interface DiscussionIndexRouteParams {
+	page?: number;
+}
+
+// TODO: Use single Ajv instance. See https://ajv.js.org/guide/managing-schemas.html.
+const ajv = new Ajv({ coerceTypes: true });
+
+// TODO: Make sure that we compile schemas only once and re-use compiled validation functions. See https://ajv.js.org/guide/getting-started.html.
+const schema: JSONSchemaType<DiscussionIndexRouteParams> = require('@Stores/Discussion/DiscussionIndexRouteParams.schema');
+const validate = ajv.compile(schema);
+
+export default class DiscussionIndexStore
+	implements IStoreWithPaging<DiscussionIndexRouteParams> {
 	@observable public folders: DiscussionFolderContract[] = [];
 	@observable public newTopic: DiscussionTopicEditStore;
 	public readonly paging = new ServerSidePagingStore(30); // Paging store
@@ -24,6 +39,7 @@ export default class DiscussionIndexStore {
 	@observable public selectedTopic?: DiscussionTopicStore = undefined;
 	@observable public showCreateNewTopic: boolean = false;
 	@observable public topics: DiscussionTopicContract[] = [];
+	private pauseNotifications = false;
 
 	public constructor(
 		public readonly loginManager: LoginManager,
@@ -48,17 +64,11 @@ export default class DiscussionIndexStore {
 
 		reaction(
 			() => this.selectedFolder,
-			(folder) => {
+			() => {
 				this.showCreateNewTopic = false;
 				this.selectedTopic = undefined;
-				this.paging.goToFirstPage();
-
-				this.loadTopics(folder);
 			},
 		);
-
-		reaction(() => this.paging.page, this.loadTopicsForCurrentFolder);
-		reaction(() => this.paging.pageSize, this.loadTopicsForCurrentFolder);
 	}
 
 	private getFolder = (
@@ -92,8 +102,8 @@ export default class DiscussionIndexStore {
 			});
 	};
 
-	private loadTopicsForCurrentFolder = (): void => {
-		this.loadTopics(this.selectedFolder);
+	private loadTopicsForCurrentFolder = (): Promise<void> => {
+		return this.loadTopics(this.selectedFolder);
 	};
 
 	private canDeleteTopic = (topic: DiscussionTopicContract): boolean => {
@@ -160,5 +170,32 @@ export default class DiscussionIndexStore {
 
 	public deleteTopic = (topic: DiscussionTopicContract): Promise<void> => {
 		return this.discussionRepo.deleteTopic({ topicId: topic.id });
+	};
+
+	public popState = false;
+
+	public readonly clearResultsByQueryKeys: (keyof DiscussionIndexRouteParams)[] = [];
+
+	@computed.struct public get routeParams(): DiscussionIndexRouteParams {
+		return {
+			page: this.paging.page,
+		};
+	}
+	public set routeParams(value: DiscussionIndexRouteParams) {
+		this.paging.page = value.page ?? 1;
+	}
+
+	public validateRouteParams = (
+		data: any,
+	): data is DiscussionIndexRouteParams => validate(data);
+
+	public updateResults = (clearResults: boolean): void => {
+		if (this.pauseNotifications) return;
+
+		this.pauseNotifications = true;
+
+		this.loadTopicsForCurrentFolder().then(() => {
+			this.pauseNotifications = false;
+		});
 	};
 }

--- a/VocaDbWeb/Scripts/Stores/Discussion/DiscussionTopicRouteParams.schema.json
+++ b/VocaDbWeb/Scripts/Stores/Discussion/DiscussionTopicRouteParams.schema.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"properties": {
+		"page": {
+			"type": "number"
+		}
+	},
+	"type": "object"
+}

--- a/VocaDbWeb/Scripts/Stores/EditableCommentsStore.ts
+++ b/VocaDbWeb/Scripts/Stores/EditableCommentsStore.ts
@@ -136,8 +136,11 @@ export default class EditableCommentsStore {
 
 		this.paging.totalItems = commentContracts.length;
 
-		if (this.ascending) this.paging.goToLastPage();
-		else commentStores = commentStores.reverse();
+		if (this.ascending) {
+			//this.paging.goToLastPage();
+		} else {
+			commentStores = commentStores.reverse();
+		}
 
 		this.comments = commentStores;
 	};

--- a/VocaDbWeb/Scripts/Stores/IStoreWithPaging.ts
+++ b/VocaDbWeb/Scripts/Stores/IStoreWithPaging.ts
@@ -1,0 +1,7 @@
+import IStoreWithUpdateResults from './IStoreWithUpdateResults';
+import ServerSidePagingStore from './ServerSidePagingStore';
+
+export default interface IStoreWithPaging<T>
+	extends IStoreWithUpdateResults<T> {
+	paging: ServerSidePagingStore;
+}

--- a/VocaDbWeb/Scripts/Stores/IStoreWithRouteParams.ts
+++ b/VocaDbWeb/Scripts/Stores/IStoreWithRouteParams.ts
@@ -1,0 +1,3 @@
+export default interface IStoreWithRouteParams<T> {
+	routeParams: T;
+}

--- a/VocaDbWeb/Scripts/Stores/IStoreWithRouteParams.ts
+++ b/VocaDbWeb/Scripts/Stores/IStoreWithRouteParams.ts
@@ -1,3 +1,7 @@
 export default interface IStoreWithRouteParams<T> {
+	// Whether currently processing popstate. This is to prevent adding the previous state to history.
+	popState: boolean;
 	routeParams: T;
+
+	validateRouteParams: (data: any) => data is T;
 }

--- a/VocaDbWeb/Scripts/Stores/IStoreWithUpdateResults.ts
+++ b/VocaDbWeb/Scripts/Stores/IStoreWithUpdateResults.ts
@@ -1,0 +1,8 @@
+import IStoreWithRouteParams from './IStoreWithRouteParams';
+
+export default interface IStoreWithUpdateResults<T>
+	extends IStoreWithRouteParams<T> {
+	clearResultsByQueryKeys: string[];
+
+	updateResults: (clearResults: boolean) => void;
+}

--- a/VocaDbWeb/Scripts/Stores/PagedItemsStore.ts
+++ b/VocaDbWeb/Scripts/Stores/PagedItemsStore.ts
@@ -31,10 +31,10 @@ export default abstract class PagedItemsStore<TModel> {
 		});
 	};
 
-	@action public clear = (): void => {
+	@action public clear = (): Promise<PartialFindResultContract<TModel>> => {
 		this.items = [];
 		this.start = 0;
-		this.loadMore();
+		return this.loadMore();
 	};
 
 	public init = (

--- a/VocaDbWeb/Scripts/Stores/Search/AlbumSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/AlbumSearchStore.ts
@@ -11,7 +11,7 @@ import AdvancedSearchFilter from './AdvancedSearchFilter';
 import ArtistFilters from './ArtistFilters';
 import { ICommonSearchStore } from './CommonSearchStore';
 import SearchCategoryBaseStore from './SearchCategoryBaseStore';
-import { SearchRouteParams, SearchType } from './SearchStore';
+import { SearchType } from './SearchStore';
 
 // Corresponds to the AlbumSortRule enum in C#.
 export enum AlbumSortRule {
@@ -126,7 +126,7 @@ export default class AlbumSearchStore extends SearchCategoryBaseStore<AlbumContr
 		'includeMembers',
 	];
 
-	@computed.struct public get routeParams(): SearchRouteParams {
+	@computed.struct public get routeParams(): AlbumSearchRouteParams {
 		return {
 			searchType: SearchType.Album,
 			advancedFilters: this.advancedFilters.filters.map((filter) => ({
@@ -149,9 +149,7 @@ export default class AlbumSearchStore extends SearchCategoryBaseStore<AlbumContr
 			viewMode: this.viewMode,
 		};
 	}
-	public set routeParams(value: SearchRouteParams) {
-		if (value.searchType !== SearchType.Album) return;
-
+	public set routeParams(value: AlbumSearchRouteParams) {
 		this.advancedFilters.filters = value.advancedFilters ?? [];
 		this.artistFilters.artistIds = value.artistId ?? [];
 		this.artistFilters.artistParticipationStatus =

--- a/VocaDbWeb/Scripts/Stores/Search/AlbumSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/AlbumSearchStore.ts
@@ -109,6 +109,23 @@ export default class AlbumSearchStore extends SearchCategoryBaseStore<AlbumContr
 		return ratings;
 	};
 
+	public readonly clearResultsByQueryKeys: (keyof AlbumSearchRouteParams)[] = [
+		'pageSize',
+		'filter',
+		'tagId',
+		'childTags',
+		'draftsOnly',
+		'searchType',
+
+		'advancedFilters',
+		'sort',
+		'discType',
+		'artistId',
+		'artistParticipationStatus',
+		'childVoicebanks',
+		'includeMembers',
+	];
+
 	@computed.struct public get routeParams(): SearchRouteParams {
 		return {
 			searchType: SearchType.Album,

--- a/VocaDbWeb/Scripts/Stores/Search/AlbumSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/AlbumSearchStore.ts
@@ -7,9 +7,11 @@ import GlobalValues from '@Shared/GlobalValues';
 import _ from 'lodash';
 import { computed, makeObservable, observable, reaction } from 'mobx';
 
+import AdvancedSearchFilter from './AdvancedSearchFilter';
 import ArtistFilters from './ArtistFilters';
 import { ICommonSearchStore } from './CommonSearchStore';
 import SearchCategoryBaseStore from './SearchCategoryBaseStore';
+import { SearchRouteParams, SearchType } from './SearchStore';
 
 // Corresponds to the AlbumSortRule enum in C#.
 export enum AlbumSortRule {
@@ -22,6 +24,25 @@ export enum AlbumSortRule {
 	RatingTotal = 'RatingTotal',
 	NameThenReleaseDate = 'NameThenReleaseDate',
 	CollectionCount = 'CollectionCount',
+}
+
+export interface AlbumSearchRouteParams {
+	advancedFilters?: AdvancedSearchFilter[];
+	artistId?: number[];
+	artistParticipationStatus?: string /* TODO: enum */;
+	childTags?: boolean;
+	childVoicebanks?: boolean;
+	discType?: string /* TODO: enum */;
+	draftsOnly?: boolean;
+	filter?: string;
+	includeMembers?: boolean;
+	page?: number;
+	pageSize?: number;
+	searchType?: SearchType.Album;
+	sort?: AlbumSortRule;
+	tag?: string;
+	tagId?: number[];
+	viewMode?: string /* TODO: enum */;
 }
 
 export default class AlbumSearchStore extends SearchCategoryBaseStore<AlbumContract> {
@@ -98,4 +119,46 @@ export default class AlbumSearchStore extends SearchCategoryBaseStore<AlbumContr
 		});
 		return ratings;
 	};
+
+	@computed.struct public get routeParams(): SearchRouteParams {
+		return {
+			searchType: SearchType.Album,
+			advancedFilters: this.advancedFilters.filters.map((filter) => ({
+				description: filter.description,
+				filterType: filter.filterType,
+				negate: filter.negate,
+				param: filter.param,
+			})),
+			artistId: this.artistFilters.artistIds,
+			artistParticipationStatus: this.artistFilters.artistParticipationStatus,
+			childTags: this.childTags,
+			childVoicebanks: this.artistFilters.childVoicebanks,
+			discType: this.albumType,
+			draftsOnly: this.draftsOnly,
+			filter: this.searchTerm,
+			page: this.paging.page,
+			pageSize: this.pageSize,
+			sort: this.sort,
+			tagId: this.tagIds,
+			viewMode: this.viewMode,
+		};
+	}
+	public set routeParams(value: SearchRouteParams) {
+		if (value.searchType !== SearchType.Album) return;
+
+		this.advancedFilters.filters = value.advancedFilters ?? [];
+		this.artistFilters.artistIds = value.artistId ?? [];
+		this.artistFilters.artistParticipationStatus =
+			value.artistParticipationStatus ?? 'Everything';
+		this.childTags = value.childTags ?? false;
+		this.artistFilters.childVoicebanks = value.childVoicebanks ?? false;
+		this.albumType = value.discType ?? 'Unknown';
+		this.draftsOnly = value.draftsOnly ?? false;
+		this.searchTerm = value.filter ?? '';
+		this.paging.page = value.page ?? 1;
+		this.pageSize = value.pageSize ?? 10;
+		this.sort = value.sort ?? AlbumSortRule.Name;
+		this.tagIds = value.tagId ?? [];
+		this.viewMode = value.viewMode ?? 'Details';
+	}
 }

--- a/VocaDbWeb/Scripts/Stores/Search/AlbumSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/AlbumSearchStore.ts
@@ -5,7 +5,7 @@ import AlbumRepository from '@Repositories/AlbumRepository';
 import ArtistRepository from '@Repositories/ArtistRepository';
 import GlobalValues from '@Shared/GlobalValues';
 import _ from 'lodash';
-import { computed, makeObservable, observable, reaction } from 'mobx';
+import { computed, makeObservable, observable } from 'mobx';
 
 import AdvancedSearchFilter from './AdvancedSearchFilter';
 import ArtistFilters from './ArtistFilters';
@@ -61,18 +61,7 @@ export default class AlbumSearchStore extends SearchCategoryBaseStore<AlbumContr
 
 		makeObservable(this);
 
-		reaction(
-			() => this.advancedFilters.filters.map((filter) => filter.description),
-			this.updateResultsWithTotalCount,
-		);
 		this.artistFilters = new ArtistFilters(values, artistRepo);
-
-		reaction(() => this.sort, this.updateResultsWithTotalCount);
-		reaction(() => this.albumType, this.updateResultsWithTotalCount);
-		reaction(
-			() => this.artistFilters.filters,
-			this.updateResultsWithTotalCount,
-		);
 	}
 
 	@computed public get fields(): string {

--- a/VocaDbWeb/Scripts/Stores/Search/AlbumSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/AlbumSearchStore.ts
@@ -143,7 +143,7 @@ export default class AlbumSearchStore extends SearchCategoryBaseStore<AlbumContr
 			draftsOnly: this.draftsOnly,
 			filter: this.searchTerm,
 			page: this.paging.page,
-			pageSize: this.pageSize,
+			pageSize: this.paging.pageSize,
 			sort: this.sort,
 			tagId: this.tagIds,
 			viewMode: this.viewMode,
@@ -162,7 +162,7 @@ export default class AlbumSearchStore extends SearchCategoryBaseStore<AlbumContr
 		this.draftsOnly = value.draftsOnly ?? false;
 		this.searchTerm = value.filter ?? '';
 		this.paging.page = value.page ?? 1;
-		this.pageSize = value.pageSize ?? 10;
+		this.paging.pageSize = value.pageSize ?? 10;
 		this.sort = value.sort ?? AlbumSortRule.Name;
 		this.tagIds = value.tagId ?? [];
 		this.viewMode = value.viewMode ?? 'Details';

--- a/VocaDbWeb/Scripts/Stores/Search/AnythingSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/AnythingSearchStore.ts
@@ -8,6 +8,18 @@ import { computed, makeObservable } from 'mobx';
 
 import { ICommonSearchStore } from './CommonSearchStore';
 import SearchCategoryBaseStore from './SearchCategoryBaseStore';
+import { SearchRouteParams, SearchType } from './SearchStore';
+
+export interface AnythingSearchRouteParams {
+	childTags?: boolean;
+	draftsOnly?: boolean;
+	filter?: string;
+	page?: number;
+	pageSize?: number;
+	searchType?: SearchType.Anything;
+	tag?: string;
+	tagId?: number[];
+}
 
 export default class AnythingSearchStore extends SearchCategoryBaseStore<EntryContract> {
 	public constructor(
@@ -47,4 +59,26 @@ export default class AnythingSearchStore extends SearchCategoryBaseStore<EntryCo
 	public entryUrl = (entry: EntryContract): string => {
 		return EntryUrlMapper.details(entry.entryType, entry.id);
 	};
+
+	@computed.struct public get routeParams(): SearchRouteParams {
+		return {
+			searchType: SearchType.Anything,
+			childTags: this.childTags,
+			draftsOnly: this.draftsOnly,
+			filter: this.searchTerm,
+			page: this.paging.page,
+			pageSize: this.pageSize,
+			tagId: this.tagIds,
+		};
+	}
+	public set routeParams(value: SearchRouteParams) {
+		if (value.searchType !== SearchType.Anything) return;
+
+		this.childTags = value.childTags ?? false;
+		this.draftsOnly = value.draftsOnly ?? false;
+		this.searchTerm = value.filter ?? '';
+		this.paging.page = value.page ?? 1;
+		this.pageSize = value.pageSize ?? 10;
+		this.tagIds = value.tagId ?? [];
+	}
 }

--- a/VocaDbWeb/Scripts/Stores/Search/AnythingSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/AnythingSearchStore.ts
@@ -60,6 +60,14 @@ export default class AnythingSearchStore extends SearchCategoryBaseStore<EntryCo
 		return EntryUrlMapper.details(entry.entryType, entry.id);
 	};
 
+	public readonly clearResultsByQueryKeys: (keyof AnythingSearchRouteParams)[] = [
+		'pageSize',
+		'filter',
+		'tagId',
+		'draftsOnly',
+		'searchType',
+	];
+
 	@computed.struct public get routeParams(): SearchRouteParams {
 		return {
 			searchType: SearchType.Anything,

--- a/VocaDbWeb/Scripts/Stores/Search/AnythingSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/AnythingSearchStore.ts
@@ -75,7 +75,7 @@ export default class AnythingSearchStore extends SearchCategoryBaseStore<EntryCo
 			draftsOnly: this.draftsOnly,
 			filter: this.searchTerm,
 			page: this.paging.page,
-			pageSize: this.pageSize,
+			pageSize: this.paging.pageSize,
 			tagId: this.tagIds,
 		};
 	}
@@ -86,7 +86,7 @@ export default class AnythingSearchStore extends SearchCategoryBaseStore<EntryCo
 		this.draftsOnly = value.draftsOnly ?? false;
 		this.searchTerm = value.filter ?? '';
 		this.paging.page = value.page ?? 1;
-		this.pageSize = value.pageSize ?? 10;
+		this.paging.pageSize = value.pageSize ?? 10;
 		this.tagIds = value.tagId ?? [];
 	}
 }

--- a/VocaDbWeb/Scripts/Stores/Search/AnythingSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/AnythingSearchStore.ts
@@ -8,7 +8,7 @@ import { computed, makeObservable } from 'mobx';
 
 import { ICommonSearchStore } from './CommonSearchStore';
 import SearchCategoryBaseStore from './SearchCategoryBaseStore';
-import { SearchRouteParams, SearchType } from './SearchStore';
+import { SearchType } from './SearchStore';
 
 export interface AnythingSearchRouteParams {
 	childTags?: boolean;
@@ -68,7 +68,7 @@ export default class AnythingSearchStore extends SearchCategoryBaseStore<EntryCo
 		'searchType',
 	];
 
-	@computed.struct public get routeParams(): SearchRouteParams {
+	@computed.struct public get routeParams(): AnythingSearchRouteParams {
 		return {
 			searchType: SearchType.Anything,
 			childTags: this.childTags,
@@ -79,9 +79,7 @@ export default class AnythingSearchStore extends SearchCategoryBaseStore<EntryCo
 			tagId: this.tagIds,
 		};
 	}
-	public set routeParams(value: SearchRouteParams) {
-		if (value.searchType !== SearchType.Anything) return;
-
+	public set routeParams(value: AnythingSearchRouteParams) {
 		this.childTags = value.childTags ?? false;
 		this.draftsOnly = value.draftsOnly ?? false;
 		this.searchTerm = value.filter ?? '';

--- a/VocaDbWeb/Scripts/Stores/Search/ArtistFilters.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/ArtistFilters.ts
@@ -35,6 +35,9 @@ export default class ArtistFilters {
 	@computed public get artistIds(): number[] {
 		return _.map(this.artists, (a) => a.id);
 	}
+	public set artistIds(value: number[]) {
+		// TODO: implement
+	}
 
 	@computed public get hasMultipleArtists(): boolean {
 		return this.artists.length > 1;

--- a/VocaDbWeb/Scripts/Stores/Search/ArtistFilters.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/ArtistFilters.ts
@@ -36,7 +36,9 @@ export default class ArtistFilters {
 		return _.map(this.artists, (a) => a.id);
 	}
 	public set artistIds(value: number[]) {
-		// TODO: implement
+		// OPTIMIZE
+		this.artists = [];
+		this.selectArtists(value);
 	}
 
 	@computed public get hasMultipleArtists(): boolean {

--- a/VocaDbWeb/Scripts/Stores/Search/ArtistSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/ArtistSearchStore.ts
@@ -125,7 +125,7 @@ export default class ArtistSearchStore extends SearchCategoryBaseStore<ArtistCon
 			filter: this.searchTerm,
 			onlyFollowedByMe: this.onlyFollowedByMe,
 			page: this.paging.page,
-			pageSize: this.pageSize,
+			pageSize: this.paging.pageSize,
 			sort: this.sort,
 			tagId: this.tagIds,
 		};
@@ -140,7 +140,7 @@ export default class ArtistSearchStore extends SearchCategoryBaseStore<ArtistCon
 		this.searchTerm = value.filter ?? '';
 		this.onlyFollowedByMe = value.onlyFollowedByMe ?? false;
 		this.paging.page = value.page ?? 1;
-		this.pageSize = value.pageSize ?? 10;
+		this.paging.pageSize = value.pageSize ?? 10;
 		this.sort = value.sort ?? ArtistSortRule.Name;
 		this.tagIds = value.tagId ?? [];
 	}

--- a/VocaDbWeb/Scripts/Stores/Search/ArtistSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/ArtistSearchStore.ts
@@ -5,7 +5,7 @@ import ArtistHelper from '@Helpers/ArtistHelper';
 import ArtistType from '@Models/Artists/ArtistType';
 import ArtistRepository from '@Repositories/ArtistRepository';
 import GlobalValues from '@Shared/GlobalValues';
-import { computed, makeObservable, observable, reaction } from 'mobx';
+import { computed, makeObservable, observable } from 'mobx';
 
 import AdvancedSearchFilter from './AdvancedSearchFilter';
 import { ICommonSearchStore } from './CommonSearchStore';
@@ -53,15 +53,6 @@ export default class ArtistSearchStore extends SearchCategoryBaseStore<ArtistCon
 		super(commonSearchStore);
 
 		makeObservable(this);
-
-		reaction(
-			() => this.advancedFilters.filters.map((filter) => filter.description),
-			this.updateResultsWithTotalCount,
-		);
-		reaction(() => this.sort, this.updateResultsWithTotalCount);
-		reaction(() => this.artistType, this.updateResultsWithTotalCount);
-		reaction(() => this.onlyFollowedByMe, this.updateResultsWithTotalCount);
-		reaction(() => this.onlyRootVoicebanks, this.updateResultsWithTotalCount);
 	}
 
 	@computed public get fields(): string {

--- a/VocaDbWeb/Scripts/Stores/Search/ArtistSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/ArtistSearchStore.ts
@@ -10,7 +10,7 @@ import { computed, makeObservable, observable } from 'mobx';
 import AdvancedSearchFilter from './AdvancedSearchFilter';
 import { ICommonSearchStore } from './CommonSearchStore';
 import SearchCategoryBaseStore from './SearchCategoryBaseStore';
-import { SearchRouteParams, SearchType } from './SearchStore';
+import { SearchType } from './SearchStore';
 
 // Corresponds to the ArtistSortRule enum in C#.
 export enum ArtistSortRule {
@@ -110,7 +110,7 @@ export default class ArtistSearchStore extends SearchCategoryBaseStore<ArtistCon
 		// TODO: onlyRootVoicebanks
 	];
 
-	@computed.struct public get routeParams(): SearchRouteParams {
+	@computed.struct public get routeParams(): ArtistSearchRouteParams {
 		return {
 			searchType: SearchType.Artist,
 			advancedFilters: this.advancedFilters.filters.map((filter) => ({
@@ -130,9 +130,7 @@ export default class ArtistSearchStore extends SearchCategoryBaseStore<ArtistCon
 			tagId: this.tagIds,
 		};
 	}
-	public set routeParams(value: SearchRouteParams) {
-		if (value.searchType !== SearchType.Artist) return;
-
+	public set routeParams(value: ArtistSearchRouteParams) {
 		this.advancedFilters.filters = value.advancedFilters ?? [];
 		this.artistType = value.artistType ?? 'Unknown';
 		this.childTags = value.childTags ?? false;

--- a/VocaDbWeb/Scripts/Stores/Search/ArtistSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/ArtistSearchStore.ts
@@ -95,6 +95,21 @@ export default class ArtistSearchStore extends SearchCategoryBaseStore<ArtistCon
 		);
 	}
 
+	public readonly clearResultsByQueryKeys: (keyof ArtistSearchRouteParams)[] = [
+		'pageSize',
+		'filter',
+		'tagId',
+		'childTags',
+		'draftsOnly',
+		'searchType',
+
+		'advancedFilters',
+		'sort',
+		'artistType',
+		'onlyFollowedByMe',
+		// TODO: onlyRootVoicebanks
+	];
+
 	@computed.struct public get routeParams(): SearchRouteParams {
 		return {
 			searchType: SearchType.Artist,

--- a/VocaDbWeb/Scripts/Stores/Search/EventSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/EventSearchStore.ts
@@ -9,7 +9,7 @@ import { computed, makeObservable, observable } from 'mobx';
 import ArtistFilters from './ArtistFilters';
 import { ICommonSearchStore } from './CommonSearchStore';
 import SearchCategoryBaseStore from './SearchCategoryBaseStore';
-import { SearchRouteParams, SearchType } from './SearchStore';
+import { SearchType } from './SearchStore';
 
 // Corresponds to the EventSortRule enum in C#.
 export enum EventSortRule {
@@ -118,7 +118,7 @@ export default class EventSearchStore extends SearchCategoryBaseStore<ReleaseEve
 		'sort',
 	];
 
-	@computed.struct public get routeParams(): SearchRouteParams {
+	@computed.struct public get routeParams(): EventSearchRouteParams {
 		return {
 			searchType: SearchType.ReleaseEvent,
 			afterDate: this.afterDate?.toISOString(),
@@ -136,9 +136,7 @@ export default class EventSearchStore extends SearchCategoryBaseStore<ReleaseEve
 			tagId: this.tagIds,
 		};
 	}
-	public set routeParams(value: SearchRouteParams) {
-		if (value.searchType !== SearchType.ReleaseEvent) return;
-
+	public set routeParams(value: EventSearchRouteParams) {
 		this.afterDate = value.afterDate ? new Date(value.afterDate) : undefined;
 		this.artistFilters.artistIds = value.artistId ?? [];
 		this.beforeDate = value.beforeDate ? new Date(value.beforeDate) : undefined;

--- a/VocaDbWeb/Scripts/Stores/Search/EventSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/EventSearchStore.ts
@@ -100,6 +100,24 @@ export default class EventSearchStore extends SearchCategoryBaseStore<ReleaseEve
 		});
 	};
 
+	public readonly clearResultsByQueryKeys: (keyof EventSearchRouteParams)[] = [
+		'pageSize',
+		'filter',
+		'tagId',
+		'childTags',
+		'draftsOnly',
+		'searchType',
+
+		'afterDate',
+		'beforeDate',
+		'artistId',
+		'childVoicebanks',
+		'includeMembers',
+		'eventCategory',
+		'onlyMyEvents',
+		'sort',
+	];
+
 	@computed.struct public get routeParams(): SearchRouteParams {
 		return {
 			searchType: SearchType.ReleaseEvent,

--- a/VocaDbWeb/Scripts/Stores/Search/EventSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/EventSearchStore.ts
@@ -131,7 +131,7 @@ export default class EventSearchStore extends SearchCategoryBaseStore<ReleaseEve
 			filter: this.searchTerm,
 			onlyMyEvents: this.onlyMyEvents,
 			page: this.paging.page,
-			pageSize: this.pageSize,
+			pageSize: this.paging.pageSize,
 			sort: this.sort,
 			tagId: this.tagIds,
 		};
@@ -149,7 +149,7 @@ export default class EventSearchStore extends SearchCategoryBaseStore<ReleaseEve
 		this.searchTerm = value.filter ?? '';
 		this.onlyMyEvents = value.onlyMyEvents ?? false;
 		this.paging.page = value.page ?? 1;
-		this.pageSize = value.pageSize ?? 10;
+		this.paging.pageSize = value.pageSize ?? 10;
 		this.sort = value.sort ?? EventSortRule.Name;
 		this.tagIds = value.tagId ?? [];
 	}

--- a/VocaDbWeb/Scripts/Stores/Search/EventSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/EventSearchStore.ts
@@ -9,6 +9,7 @@ import { computed, makeObservable, observable, reaction } from 'mobx';
 import ArtistFilters from './ArtistFilters';
 import { ICommonSearchStore } from './CommonSearchStore';
 import SearchCategoryBaseStore from './SearchCategoryBaseStore';
+import { SearchRouteParams, SearchType } from './SearchStore';
 
 // Corresponds to the EventSortRule enum in C#.
 export enum EventSortRule {
@@ -18,6 +19,25 @@ export enum EventSortRule {
 	AdditionDate = 'AdditionDate',
 	SeriesName = 'SeriesName',
 	VenueName = 'VenueName',
+}
+
+export interface EventSearchRouteParams {
+	afterDate?: string /* TODO: use Date */;
+	artistId?: number[];
+	beforeDate?: string /* TODO: use Date */;
+	childTags?: boolean;
+	childVoicebanks?: boolean;
+	draftsOnly?: boolean;
+	eventCategory?: string;
+	filter?: string;
+	includeMembers?: boolean;
+	onlyMyEvents?: boolean;
+	page?: number;
+	pageSize?: number;
+	searchType?: SearchType.ReleaseEvent;
+	sort?: EventSortRule;
+	tag?: string;
+	tagId?: number[];
 }
 
 export default class EventSearchStore extends SearchCategoryBaseStore<ReleaseEventContract> {
@@ -89,4 +109,40 @@ export default class EventSearchStore extends SearchCategoryBaseStore<ReleaseEve
 			},
 		});
 	};
+
+	@computed.struct public get routeParams(): SearchRouteParams {
+		return {
+			searchType: SearchType.ReleaseEvent,
+			afterDate: this.afterDate?.toISOString(),
+			artistId: this.artistFilters.artistIds,
+			beforeDate: this.beforeDate?.toISOString(),
+			childTags: this.childTags,
+			childVoicebanks: this.artistFilters.childVoicebanks,
+			draftsOnly: this.draftsOnly,
+			eventCategory: this.category,
+			filter: this.searchTerm,
+			onlyMyEvents: this.onlyMyEvents,
+			page: this.paging.page,
+			pageSize: this.pageSize,
+			sort: this.sort,
+			tagId: this.tagIds,
+		};
+	}
+	public set routeParams(value: SearchRouteParams) {
+		if (value.searchType !== SearchType.ReleaseEvent) return;
+
+		this.afterDate = value.afterDate ? new Date(value.afterDate) : undefined;
+		this.artistFilters.artistIds = value.artistId ?? [];
+		this.beforeDate = value.beforeDate ? new Date(value.beforeDate) : undefined;
+		this.childTags = value.childTags ?? false;
+		this.artistFilters.childVoicebanks = value.childVoicebanks ?? false;
+		this.draftsOnly = value.draftsOnly ?? false;
+		this.category = value.eventCategory ?? '';
+		this.searchTerm = value.filter ?? '';
+		this.onlyMyEvents = value.onlyMyEvents ?? false;
+		this.paging.page = value.page ?? 1;
+		this.pageSize = value.pageSize ?? 10;
+		this.sort = value.sort ?? EventSortRule.Name;
+		this.tagIds = value.tagId ?? [];
+	}
 }

--- a/VocaDbWeb/Scripts/Stores/Search/EventSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/EventSearchStore.ts
@@ -4,7 +4,7 @@ import ReleaseEventContract from '@DataContracts/ReleaseEvents/ReleaseEventContr
 import ArtistRepository from '@Repositories/ArtistRepository';
 import ReleaseEventRepository from '@Repositories/ReleaseEventRepository';
 import GlobalValues from '@Shared/GlobalValues';
-import { computed, makeObservable, observable, reaction } from 'mobx';
+import { computed, makeObservable, observable } from 'mobx';
 
 import ArtistFilters from './ArtistFilters';
 import { ICommonSearchStore } from './CommonSearchStore';
@@ -60,16 +60,6 @@ export default class EventSearchStore extends SearchCategoryBaseStore<ReleaseEve
 		makeObservable(this);
 
 		this.artistFilters = new ArtistFilters(values, artistRepo);
-
-		reaction(() => this.afterDate, this.updateResultsWithTotalCount);
-		reaction(
-			() => this.artistFilters.filters,
-			this.updateResultsWithTotalCount,
-		);
-		reaction(() => this.beforeDate, this.updateResultsWithTotalCount);
-		reaction(() => this.category, this.updateResultsWithTotalCount);
-		reaction(() => this.onlyMyEvents, this.updateResultsWithTotalCount);
-		reaction(() => this.sort, this.updateResultsWithTotalCount);
 	}
 
 	@computed public get fields(): string {

--- a/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
@@ -2,6 +2,7 @@ import EntryWithTagUsagesContract from '@DataContracts/Base/EntryWithTagUsagesCo
 import PagingProperties from '@DataContracts/PagingPropertiesContract';
 import PartialFindResultContract from '@DataContracts/PartialFindResultContract';
 import TagBaseContract from '@DataContracts/Tag/TagBaseContract';
+import IStoreWithRouteParams from '@Stores/IStoreWithRouteParams';
 import ServerSidePagingStore from '@Stores/ServerSidePagingStore';
 import _ from 'lodash';
 import {
@@ -16,9 +17,11 @@ import moment from 'moment';
 
 import AdvancedSearchFilters from './AdvancedSearchFilters';
 import { ICommonSearchStore } from './CommonSearchStore';
+import { SearchRouteParams } from './SearchStore';
 import TagFilter from './TagFilter';
 
-export interface ISearchCategoryBaseStore {
+export interface ISearchCategoryBaseStore
+	extends IStoreWithRouteParams<SearchRouteParams> {
 	updateResultsWithTotalCount: () => void;
 }
 
@@ -99,7 +102,9 @@ export default abstract class SearchCategoryBaseStore<
 		return _.map(this.tags, (t) => t.id);
 	}
 	public set tagIds(value: number[]) {
-		// TODO: implement
+		// OPTIMIZE
+		this.commonSearchStore.tagFilters.tags = [];
+		this.commonSearchStore.tagFilters.addTags(value);
 	}
 
 	public formatDate = (dateStr: string): string => {
@@ -118,6 +123,8 @@ export default abstract class SearchCategoryBaseStore<
 	@action public selectTag = (tag: TagBaseContract): void => {
 		this.tags = [TagFilter.fromContract(tag)];
 	};
+
+	public abstract routeParams: SearchRouteParams;
 
 	@action public updateResults = (clearResults: boolean): void => {
 		// Disable duplicate updates

--- a/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
@@ -2,7 +2,7 @@ import EntryWithTagUsagesContract from '@DataContracts/Base/EntryWithTagUsagesCo
 import PagingProperties from '@DataContracts/PagingPropertiesContract';
 import PartialFindResultContract from '@DataContracts/PartialFindResultContract';
 import TagBaseContract from '@DataContracts/Tag/TagBaseContract';
-import IStoreWithUpdateResults from '@Stores/IStoreWithUpdateResults';
+import IStoreWithPaging from '@Stores/IStoreWithPaging';
 import ServerSidePagingStore from '@Stores/ServerSidePagingStore';
 import _ from 'lodash';
 import {
@@ -21,9 +21,10 @@ import { SearchRouteParams } from './SearchStore';
 import TagFilter from './TagFilter';
 
 export interface ISearchCategoryBaseStore
-	extends IStoreWithUpdateResults<SearchRouteParams> {
-	paging: ServerSidePagingStore;
-
+	extends Omit<
+		IStoreWithPaging<SearchRouteParams>,
+		'popState' | 'validateRouteParams'
+	> {
 	updateResultsWithTotalCount: () => void;
 }
 

--- a/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
@@ -53,7 +53,6 @@ export default abstract class SearchCategoryBaseStore<
 				commonSearchStore.pageSize = pageSize;
 			},
 		);
-		reaction(() => this.paging.page, this.updateResultsWithoutTotalCount);
 	}
 
 	@computed public get childTags(): boolean {

--- a/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
@@ -22,6 +22,8 @@ import TagFilter from './TagFilter';
 
 export interface ISearchCategoryBaseStore
 	extends IStoreWithUpdateResults<SearchRouteParams> {
+	paging: ServerSidePagingStore;
+
 	updateResultsWithTotalCount: () => void;
 }
 
@@ -132,8 +134,6 @@ export default abstract class SearchCategoryBaseStore<
 
 		this.pauseNotifications = true;
 		this.loading = true;
-
-		if (clearResults) this.paging.goToFirstPage();
 
 		const pagingProperties = this.paging.getPagingProperties(clearResults);
 

--- a/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
@@ -90,7 +90,7 @@ export default abstract class SearchCategoryBaseStore<
 		return this.commonSearchStore.showTags;
 	}
 	public set showTags(value: boolean) {
-		this.showTags = value;
+		this.commonSearchStore.showTags = value;
 	}
 
 	@computed public get tags(): TagFilter[] {

--- a/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
@@ -37,7 +37,6 @@ export default abstract class SearchCategoryBaseStore<
 	@observable public loading = true; // Currently loading for data
 	@observable public page: TEntry[] = []; // Current page of items
 	public readonly paging = new ServerSidePagingStore(); // Paging store
-	public pauseNotifications = false;
 
 	public constructor(commonSearchStore: ICommonSearchStore) {
 		makeObservable(this);
@@ -128,6 +127,8 @@ export default abstract class SearchCategoryBaseStore<
 
 	public abstract clearResultsByQueryKeys: string[];
 	public abstract routeParams: SearchRouteParams;
+
+	private pauseNotifications = false;
 
 	@action public updateResults = (clearResults: boolean): void => {
 		// Disable duplicate updates

--- a/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
@@ -2,7 +2,7 @@ import EntryWithTagUsagesContract from '@DataContracts/Base/EntryWithTagUsagesCo
 import PagingProperties from '@DataContracts/PagingPropertiesContract';
 import PartialFindResultContract from '@DataContracts/PartialFindResultContract';
 import TagBaseContract from '@DataContracts/Tag/TagBaseContract';
-import IStoreWithRouteParams from '@Stores/IStoreWithRouteParams';
+import IStoreWithUpdateResults from '@Stores/IStoreWithUpdateResults';
 import ServerSidePagingStore from '@Stores/ServerSidePagingStore';
 import _ from 'lodash';
 import {
@@ -21,7 +21,7 @@ import { SearchRouteParams } from './SearchStore';
 import TagFilter from './TagFilter';
 
 export interface ISearchCategoryBaseStore
-	extends IStoreWithRouteParams<SearchRouteParams> {
+	extends IStoreWithUpdateResults<SearchRouteParams> {
 	updateResultsWithTotalCount: () => void;
 }
 
@@ -123,6 +123,7 @@ export default abstract class SearchCategoryBaseStore<
 		this.tags = [TagFilter.fromContract(tag)];
 	};
 
+	public abstract clearResultsByQueryKeys: string[];
 	public abstract routeParams: SearchRouteParams;
 
 	@action public updateResults = (clearResults: boolean): void => {

--- a/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchCategoryBaseStore.ts
@@ -56,17 +56,29 @@ export default abstract class SearchCategoryBaseStore<
 	@computed public get childTags(): boolean {
 		return this.commonSearchStore.tagFilters.childTags;
 	}
+	public set childTags(value: boolean) {
+		this.commonSearchStore.tagFilters.childTags = value;
+	}
 
 	@computed public get draftsOnly(): boolean {
 		return this.commonSearchStore.draftsOnly;
+	}
+	public set draftsOnly(value: boolean) {
+		this.commonSearchStore.draftsOnly = value;
 	}
 
 	@computed public get pageSize(): number {
 		return this.commonSearchStore.pageSize;
 	}
+	public set pageSize(value: number) {
+		this.commonSearchStore.pageSize = value;
+	}
 
 	@computed public get searchTerm(): string {
 		return this.commonSearchStore.searchTerm;
+	}
+	public set searchTerm(value: string) {
+		this.commonSearchStore.searchTerm = value;
 	}
 
 	@computed public get showTags(): boolean {
@@ -85,6 +97,9 @@ export default abstract class SearchCategoryBaseStore<
 
 	@computed public get tagIds(): number[] {
 		return _.map(this.tags, (t) => t.id);
+	}
+	public set tagIds(value: number[]) {
+		// TODO: implement
 	}
 
 	public formatDate = (dateStr: string): string => {

--- a/VocaDbWeb/Scripts/Stores/Search/SearchRouteParams.schema.json
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchRouteParams.schema.json
@@ -1,0 +1,443 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"anyOf": [
+		{
+			"$ref": "#/definitions/AnythingSearchRouteParams"
+		},
+		{
+			"$ref": "#/definitions/ArtistSearchRouteParams"
+		},
+		{
+			"$ref": "#/definitions/EventSearchRouteParams"
+		},
+		{
+			"$ref": "#/definitions/SongSearchRouteParams"
+		},
+		{
+			"$ref": "#/definitions/TagSearchRouteParams"
+		},
+		{
+			"$ref": "#/definitions/AlbumSearchRouteParams"
+		}
+	],
+	"definitions": {
+		"AdvancedFilterType": {
+			"enum": [
+				"ArtistType",
+				"HasAlbum",
+				"HasMedia",
+				"HasMultipleVoicebanks",
+				"HasOriginalMedia",
+				"HasPublishDate",
+				"HasStoreLink",
+				"HasTracks",
+				"HasUserAccount",
+				"Lyrics",
+				"LyricsContent",
+				"NoCoverPicture",
+				"Nothing",
+				"RootVoicebank",
+				"VoiceProvider",
+				"WebLink"
+			],
+			"type": "string"
+		},
+		"AlbumSearchRouteParams": {
+			"properties": {
+				"advancedFilters": {
+					"items": {
+						"$ref": "#/definitions/default"
+					},
+					"type": "array"
+				},
+				"artistId": {
+					"items": {
+						"type": "number"
+					},
+					"type": "array"
+				},
+				"artistParticipationStatus": {
+					"type": "string"
+				},
+				"childTags": {
+					"type": "boolean"
+				},
+				"childVoicebanks": {
+					"type": "boolean"
+				},
+				"discType": {
+					"type": "string"
+				},
+				"draftsOnly": {
+					"type": "boolean"
+				},
+				"filter": {
+					"type": "string"
+				},
+				"includeMembers": {
+					"type": "boolean"
+				},
+				"page": {
+					"type": "number"
+				},
+				"pageSize": {
+					"type": "number"
+				},
+				"searchType": {
+					"enum": ["Album"],
+					"type": "string"
+				},
+				"sort": {
+					"enum": [
+						"AdditionDate",
+						"CollectionCount",
+						"Name",
+						"NameThenReleaseDate",
+						"None",
+						"RatingAverage",
+						"RatingTotal",
+						"ReleaseDate",
+						"ReleaseDateWithNulls"
+					],
+					"type": "string"
+				},
+				"tag": {
+					"type": "string"
+				},
+				"tagId": {
+					"items": {
+						"type": "number"
+					},
+					"type": "array"
+				},
+				"viewMode": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"AnythingSearchRouteParams": {
+			"properties": {
+				"childTags": {
+					"type": "boolean"
+				},
+				"draftsOnly": {
+					"type": "boolean"
+				},
+				"filter": {
+					"type": "string"
+				},
+				"page": {
+					"type": "number"
+				},
+				"pageSize": {
+					"type": "number"
+				},
+				"searchType": {
+					"enum": ["Anything"],
+					"type": "string"
+				},
+				"tag": {
+					"type": "string"
+				},
+				"tagId": {
+					"items": {
+						"type": "number"
+					},
+					"type": "array"
+				}
+			},
+			"type": "object"
+		},
+		"ArtistSearchRouteParams": {
+			"properties": {
+				"advancedFilters": {
+					"items": {
+						"$ref": "#/definitions/default"
+					},
+					"type": "array"
+				},
+				"artistType": {
+					"type": "string"
+				},
+				"childTags": {
+					"type": "boolean"
+				},
+				"draftsOnly": {
+					"type": "boolean"
+				},
+				"filter": {
+					"type": "string"
+				},
+				"onlyFollowedByMe": {
+					"type": "boolean"
+				},
+				"page": {
+					"type": "number"
+				},
+				"pageSize": {
+					"type": "number"
+				},
+				"searchType": {
+					"enum": ["Artist"],
+					"type": "string"
+				},
+				"sort": {
+					"enum": [
+						"AdditionDate",
+						"AdditionDateAsc",
+						"FollowerCount",
+						"Name",
+						"None",
+						"ReleaseDate",
+						"SongCount",
+						"SongRating"
+					],
+					"type": "string"
+				},
+				"tag": {
+					"type": "string"
+				},
+				"tagId": {
+					"items": {
+						"type": "number"
+					},
+					"type": "array"
+				}
+			},
+			"type": "object"
+		},
+		"EventSearchRouteParams": {
+			"properties": {
+				"afterDate": {
+					"format": "date-time",
+					"type": "string"
+				},
+				"artistId": {
+					"items": {
+						"type": "number"
+					},
+					"type": "array"
+				},
+				"beforeDate": {
+					"format": "date-time",
+					"type": "string"
+				},
+				"childTags": {
+					"type": "boolean"
+				},
+				"childVoicebanks": {
+					"type": "boolean"
+				},
+				"draftsOnly": {
+					"type": "boolean"
+				},
+				"eventCategory": {
+					"type": "string"
+				},
+				"filter": {
+					"type": "string"
+				},
+				"includeMembers": {
+					"type": "boolean"
+				},
+				"onlyMyEvents": {
+					"type": "boolean"
+				},
+				"page": {
+					"type": "number"
+				},
+				"pageSize": {
+					"type": "number"
+				},
+				"searchType": {
+					"enum": ["ReleaseEvent"],
+					"type": "string"
+				},
+				"sort": {
+					"enum": [
+						"AdditionDate",
+						"Date",
+						"Name",
+						"None",
+						"SeriesName",
+						"VenueName"
+					],
+					"type": "string"
+				},
+				"tag": {
+					"type": "string"
+				},
+				"tagId": {
+					"items": {
+						"type": "number"
+					},
+					"type": "array"
+				}
+			},
+			"type": "object"
+		},
+		"SongSearchRouteParams": {
+			"properties": {
+				"advancedFilters": {
+					"items": {
+						"$ref": "#/definitions/default"
+					},
+					"type": "array"
+				},
+				"artistId": {
+					"items": {
+						"type": "number"
+					},
+					"type": "array"
+				},
+				"artistParticipationStatus": {
+					"type": "string"
+				},
+				"autoplay": {
+					"type": "boolean"
+				},
+				"childTags": {
+					"type": "boolean"
+				},
+				"childVoicebanks": {
+					"type": "boolean"
+				},
+				"dateDay": {
+					"type": "number"
+				},
+				"dateMonth": {
+					"type": "number"
+				},
+				"dateYear": {
+					"type": "number"
+				},
+				"draftsOnly": {
+					"type": "boolean"
+				},
+				"eventId": {
+					"type": "number"
+				},
+				"filter": {
+					"type": "string"
+				},
+				"includeMembers": {
+					"type": "boolean"
+				},
+				"maxLength": {
+					"type": "number"
+				},
+				"maxMilliBpm": {
+					"type": "number"
+				},
+				"minLength": {
+					"type": "number"
+				},
+				"minMilliBpm": {
+					"type": "number"
+				},
+				"minScore": {
+					"type": "number"
+				},
+				"onlyRatedSongs": {
+					"type": "boolean"
+				},
+				"onlyWithPVs": {
+					"type": "boolean"
+				},
+				"page": {
+					"type": "number"
+				},
+				"pageSize": {
+					"type": "number"
+				},
+				"parentVersionId": {
+					"type": "number"
+				},
+				"searchType": {
+					"enum": ["Song"],
+					"type": "string"
+				},
+				"shuffle": {
+					"type": "boolean"
+				},
+				"since": {
+					"type": "number"
+				},
+				"songType": {
+					"type": "string"
+				},
+				"sort": {
+					"enum": [
+						"AdditionDate",
+						"FavoritedTimes",
+						"Name",
+						"None",
+						"PublishDate",
+						"RatingScore",
+						"TagUsageCount"
+					],
+					"type": "string"
+				},
+				"tag": {
+					"type": "string"
+				},
+				"tagId": {
+					"items": {
+						"type": "number"
+					},
+					"type": "array"
+				},
+				"unifyEntryTypesAndTags": {
+					"type": "boolean"
+				},
+				"viewMode": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"TagSearchRouteParams": {
+			"properties": {
+				"categoryName": {
+					"type": "string"
+				},
+				"filter": {
+					"type": "string"
+				},
+				"page": {
+					"type": "number"
+				},
+				"pageSize": {
+					"type": "number"
+				},
+				"searchType": {
+					"enum": ["Tag"],
+					"type": "string"
+				},
+				"sort": {
+					"enum": ["AdditionDate", "Name", "Nothing", "UsageCount"],
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"default": {
+			"properties": {
+				"description": {
+					"type": "string"
+				},
+				"filterType": {
+					"$ref": "#/definitions/AdvancedFilterType"
+				},
+				"negate": {
+					"type": "boolean"
+				},
+				"param": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		}
+	}
+}

--- a/VocaDbWeb/Scripts/Stores/Search/SearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchStore.ts
@@ -121,10 +121,7 @@ export default class SearchStore
 		);
 		this.tagSearchStore = new TagSearchStore(this, values, tagRepo);
 
-		reaction(
-			() => this.showTags,
-			this.currentCategoryStore.updateResultsWithTotalCount,
-		);
+		reaction(() => this.showTags, this.updateResultsWithTotalCount);
 
 		tagRepo
 			.getTopTags({
@@ -226,5 +223,9 @@ export default class SearchStore
 
 	public updateResults = (clearResults: boolean): void => {
 		this.currentCategoryStore.updateResults(clearResults);
+	};
+
+	public updateResultsWithTotalCount = (): void => {
+		this.currentCategoryStore.updateResultsWithTotalCount();
 	};
 }

--- a/VocaDbWeb/Scripts/Stores/Search/SearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchStore.ts
@@ -9,7 +9,7 @@ import TagRepository from '@Repositories/TagRepository';
 import UserRepository from '@Repositories/UserRepository';
 import GlobalValues from '@Shared/GlobalValues';
 import UrlMapper from '@Shared/UrlMapper';
-import IStoreWithRouteParams from '@Stores/IStoreWithRouteParams';
+import IStoreWithUpdateResults from '@Stores/IStoreWithUpdateResults';
 import PVPlayersFactory from '@Stores/PVs/PVPlayersFactory';
 import {
 	computed,
@@ -51,7 +51,7 @@ export type SearchRouteParams =
 	| TagSearchRouteParams;
 
 export default class SearchStore
-	implements ICommonSearchStore, IStoreWithRouteParams<SearchRouteParams> {
+	implements ICommonSearchStore, IStoreWithUpdateResults<SearchRouteParams> {
 	public readonly albumSearchStore: AlbumSearchStore;
 	public readonly anythingSearchStore: AnythingSearchStore;
 	public readonly artistSearchStore: ArtistSearchStore;
@@ -110,7 +110,10 @@ export default class SearchStore
 		);
 		this.tagSearchStore = new TagSearchStore(this, values, tagRepo);
 
-		reaction(() => this.showTags, this.updateResults);
+		reaction(
+			() => this.showTags,
+			this.currentCategoryStore.updateResultsWithTotalCount,
+		);
 
 		tagRepo
 			.getTopTags({
@@ -186,6 +189,10 @@ export default class SearchStore
 		return this.getCategoryStore(this.searchType);
 	}
 
+	public get clearResultsByQueryKeys(): string[] {
+		return this.currentCategoryStore.clearResultsByQueryKeys;
+	}
+
 	@computed public get routeParams(): SearchRouteParams {
 		return this.currentCategoryStore.routeParams;
 	}
@@ -195,7 +202,7 @@ export default class SearchStore
 		this.currentCategoryStore.routeParams = value;
 	}
 
-	public updateResults = (): void => {
-		this.currentCategoryStore.updateResultsWithTotalCount();
+	public updateResults = (clearResults: boolean): void => {
+		this.currentCategoryStore.updateResults(clearResults);
 	};
 }

--- a/VocaDbWeb/Scripts/Stores/Search/SearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchStore.ts
@@ -18,15 +18,19 @@ import {
 	runInAction,
 } from 'mobx';
 
-import AlbumSearchStore from './AlbumSearchStore';
-import AnythingSearchStore from './AnythingSearchStore';
-import ArtistSearchStore from './ArtistSearchStore';
+import AlbumSearchStore, { AlbumSearchRouteParams } from './AlbumSearchStore';
+import AnythingSearchStore, {
+	AnythingSearchRouteParams,
+} from './AnythingSearchStore';
+import ArtistSearchStore, {
+	ArtistSearchRouteParams,
+} from './ArtistSearchStore';
 import { ICommonSearchStore } from './CommonSearchStore';
-import EventSearchStore from './EventSearchStore';
+import EventSearchStore, { EventSearchRouteParams } from './EventSearchStore';
 import { ISearchCategoryBaseStore } from './SearchCategoryBaseStore';
-import SongSearchStore from './SongSearchStore';
+import SongSearchStore, { SongSearchRouteParams } from './SongSearchStore';
 import TagFilters from './TagFilters';
-import TagSearchStore from './TagSearchStore';
+import TagSearchStore, { TagSearchRouteParams } from './TagSearchStore';
 
 export enum SearchType {
 	Anything = 'Anything',
@@ -36,6 +40,14 @@ export enum SearchType {
 	Song = 'Song',
 	Tag = 'Tag',
 }
+
+export type SearchRouteParams =
+	| AnythingSearchRouteParams
+	| AlbumSearchRouteParams
+	| ArtistSearchRouteParams
+	| EventSearchRouteParams
+	| SongSearchRouteParams
+	| TagSearchRouteParams;
 
 export default class SearchStore implements ICommonSearchStore {
 	public readonly albumSearchStore: AlbumSearchStore;

--- a/VocaDbWeb/Scripts/Stores/Search/SearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchStore.ts
@@ -11,6 +11,7 @@ import GlobalValues from '@Shared/GlobalValues';
 import UrlMapper from '@Shared/UrlMapper';
 import IStoreWithUpdateResults from '@Stores/IStoreWithUpdateResults';
 import PVPlayersFactory from '@Stores/PVs/PVPlayersFactory';
+import ServerSidePagingStore from '@Stores/ServerSidePagingStore';
 import {
 	computed,
 	makeObservable,
@@ -187,6 +188,10 @@ export default class SearchStore
 
 	public get currentCategoryStore(): ISearchCategoryBaseStore {
 		return this.getCategoryStore(this.searchType);
+	}
+
+	public get paging(): ServerSidePagingStore {
+		return this.currentCategoryStore.paging;
 	}
 
 	public get clearResultsByQueryKeys(): string[] {

--- a/VocaDbWeb/Scripts/Stores/Search/SearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchStore.ts
@@ -216,16 +216,12 @@ export default class SearchStore
 		this.currentCategoryStore.routeParams = value;
 	}
 
-	public validateRouteParams = (data: any): data is SearchRouteParams => {
-		if (validate(data)) return true;
-		return false;
-	};
+	public validateRouteParams = (data: any): data is SearchRouteParams =>
+		validate(data);
 
-	public updateResults = (clearResults: boolean): void => {
+	public updateResults = (clearResults: boolean): void =>
 		this.currentCategoryStore.updateResults(clearResults);
-	};
 
-	public updateResultsWithTotalCount = (): void => {
+	public updateResultsWithTotalCount = (): void =>
 		this.currentCategoryStore.updateResultsWithTotalCount();
-	};
 }

--- a/VocaDbWeb/Scripts/Stores/Search/SearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchStore.ts
@@ -59,7 +59,6 @@ export default class SearchStore
 	public readonly songSearchStore: SongSearchStore;
 	public readonly tagSearchStore: TagSearchStore;
 
-	@observable public currentSearchType = SearchType.Anything;
 	@observable public draftsOnly = false;
 	@observable public genreTags: TagBaseContract[] = [];
 	@observable public pageSize = 10;
@@ -111,19 +110,7 @@ export default class SearchStore
 		);
 		this.tagSearchStore = new TagSearchStore(this, values, tagRepo);
 
-		reaction(() => this.pageSize, this.updateResults);
-		reaction(() => this.searchTerm, this.updateResults);
-		reaction(() => this.tagFilters.filters, this.updateResults);
-		reaction(() => this.draftsOnly, this.updateResults);
 		reaction(() => this.showTags, this.updateResults);
-
-		reaction(
-			() => this.searchType,
-			(val) => {
-				this.updateResults();
-				this.currentSearchType = val;
-			},
-		);
 
 		tagRepo
 			.getTopTags({

--- a/VocaDbWeb/Scripts/Stores/Search/SearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SearchStore.ts
@@ -9,6 +9,7 @@ import TagRepository from '@Repositories/TagRepository';
 import UserRepository from '@Repositories/UserRepository';
 import GlobalValues from '@Shared/GlobalValues';
 import UrlMapper from '@Shared/UrlMapper';
+import IStoreWithRouteParams from '@Stores/IStoreWithRouteParams';
 import PVPlayersFactory from '@Stores/PVs/PVPlayersFactory';
 import {
 	computed,
@@ -49,7 +50,8 @@ export type SearchRouteParams =
 	| SongSearchRouteParams
 	| TagSearchRouteParams;
 
-export default class SearchStore implements ICommonSearchStore {
+export default class SearchStore
+	implements ICommonSearchStore, IStoreWithRouteParams<SearchRouteParams> {
 	public readonly albumSearchStore: AlbumSearchStore;
 	public readonly anythingSearchStore: AnythingSearchStore;
 	public readonly artistSearchStore: ArtistSearchStore;
@@ -195,6 +197,15 @@ export default class SearchStore implements ICommonSearchStore {
 
 	public get currentCategoryStore(): ISearchCategoryBaseStore {
 		return this.getCategoryStore(this.searchType);
+	}
+
+	@computed public get routeParams(): SearchRouteParams {
+		return this.currentCategoryStore.routeParams;
+	}
+	public set routeParams(value: SearchRouteParams) {
+		value.searchType ??= SearchType.Anything;
+		this.searchType = value.searchType;
+		this.currentCategoryStore.routeParams = value;
 	}
 
 	public updateResults = (): void => {

--- a/VocaDbWeb/Scripts/Stores/Search/SongSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SongSearchStore.ts
@@ -281,6 +281,38 @@ export default class SongSearchStore
 		return this.pvServiceIcons.getIconUrls(services);
 	};
 
+	public readonly clearResultsByQueryKeys: (keyof SongSearchRouteParams)[] = [
+		'pageSize',
+		'filter',
+		'tagId',
+		'childTags',
+		'draftsOnly',
+		'searchType',
+
+		'advancedFilters',
+		'artistId',
+		'artistParticipationStatus',
+		'childVoicebanks',
+		'includeMembers',
+		'dateYear',
+		'dateMonth',
+		'dateDay',
+		'eventId',
+		'minScore',
+		'onlyRatedSongs',
+		'parentVersionId',
+		'onlyWithPVs',
+		'since',
+		'songType',
+		'sort',
+		'unifyEntryTypesAndTags',
+		'viewMode',
+		'minMilliBpm',
+		'maxMilliBpm',
+		'minLength',
+		'maxLength',
+	];
+
 	@computed.struct public get routeParams(): SearchRouteParams {
 		return {
 			searchType: SearchType.Song,

--- a/VocaDbWeb/Scripts/Stores/Search/SongSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SongSearchStore.ts
@@ -338,7 +338,7 @@ export default class SongSearchStore
 			onlyRatedSongs: this.onlyRatedSongs,
 			onlyWithPVs: this.pvsOnly,
 			page: this.paging.page,
-			pageSize: this.pageSize,
+			pageSize: this.paging.pageSize,
 			parentVersionId: this.parentVersion.id,
 			// TODO: shuffle
 			since: this.since,
@@ -373,7 +373,7 @@ export default class SongSearchStore
 		this.onlyRatedSongs = value.onlyRatedSongs ?? false;
 		this.pvsOnly = value.onlyWithPVs ?? false;
 		this.paging.page = value.page ?? 1;
-		this.pageSize = value.pageSize ?? 10;
+		this.paging.pageSize = value.pageSize ?? 10;
 		this.parentVersion.selectEntry(value.parentVersionId);
 		// TODO: shuffle
 		this.since = value.since;

--- a/VocaDbWeb/Scripts/Stores/Search/SongSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SongSearchStore.ts
@@ -125,17 +125,14 @@ export default class SongSearchStore
 		this.artistFilters = new ArtistFilters(values, artistRepo);
 
 		this.releaseEvent = new BasicEntryLinkStore<IEntryWithIdAndName>(
-			{ id: undefined!, name: undefined },
 			(entryId) =>
 				this.eventRepo
 					? eventRepo.getOne({ id: entryId })
 					: Promise.resolve(undefined),
 		);
 
-		this.parentVersion = new BasicEntryLinkStore<SongContract>(
-			undefined,
-			(entryId) =>
-				songRepo.getOne({ id: entryId, lang: values.languagePreference }),
+		this.parentVersion = new BasicEntryLinkStore<SongContract>((entryId) =>
+			songRepo.getOne({ id: entryId, lang: values.languagePreference }),
 		);
 
 		this.pvPlayerStore = new PVPlayerStore(
@@ -366,7 +363,7 @@ export default class SongSearchStore
 		this.dateMonth = value.dateMonth;
 		this.dateYear = value.dateYear;
 		this.draftsOnly = value.draftsOnly ?? false;
-		this.releaseEvent.id = value.eventId;
+		this.releaseEvent.selectEntry(value.eventId);
 		this.searchTerm = value.filter ?? '';
 		this.maxLengthFilter.length = value.maxLength ?? 0;
 		this.maxBpmFilter.milliBpm = value.maxMilliBpm;
@@ -377,7 +374,7 @@ export default class SongSearchStore
 		this.pvsOnly = value.onlyWithPVs ?? false;
 		this.paging.page = value.page ?? 1;
 		this.pageSize = value.pageSize ?? 10;
-		this.parentVersion.id = value.parentVersionId;
+		this.parentVersion.selectEntry(value.parentVersionId);
 		// TODO: shuffle
 		this.since = value.since;
 		this.songType = value.songType ?? 'Unspecified';

--- a/VocaDbWeb/Scripts/Stores/Search/SongSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SongSearchStore.ts
@@ -27,7 +27,7 @@ import AdvancedSearchFilter from './AdvancedSearchFilter';
 import ArtistFilters from './ArtistFilters';
 import { ICommonSearchStore } from './CommonSearchStore';
 import SearchCategoryBaseStore from './SearchCategoryBaseStore';
-import { SearchRouteParams, SearchType } from './SearchStore';
+import { SearchType } from './SearchStore';
 import SongBpmFilter from './SongBpmFilter';
 import SongLengthFilter from './SongLengthFilter';
 
@@ -310,7 +310,7 @@ export default class SongSearchStore
 		'maxLength',
 	];
 
-	@computed.struct public get routeParams(): SearchRouteParams {
+	@computed.struct public get routeParams(): SongSearchRouteParams {
 		return {
 			searchType: SearchType.Song,
 			advancedFilters: this.advancedFilters.filters.map((filter) => ({
@@ -349,9 +349,7 @@ export default class SongSearchStore
 			viewMode: this.viewMode,
 		};
 	}
-	public set routeParams(value: SearchRouteParams) {
-		if (value.searchType !== SearchType.Song) return;
-
+	public set routeParams(value: SongSearchRouteParams) {
 		this.advancedFilters.filters = value.advancedFilters ?? [];
 		this.artistFilters.artistIds = value.artistId ?? [];
 		this.artistFilters.artistParticipationStatus =

--- a/VocaDbWeb/Scripts/Stores/Search/SongSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/SongSearchStore.ts
@@ -20,7 +20,7 @@ import PlayListRepositoryForSongsAdapter, {
 import PlayListStore from '@Stores/Song/PlayList/PlayListStore';
 import SongWithPreviewStore from '@Stores/Song/SongWithPreviewStore';
 import _ from 'lodash';
-import { computed, makeObservable, observable, reaction } from 'mobx';
+import { computed, makeObservable, observable } from 'mobx';
 import moment from 'moment';
 
 import AdvancedSearchFilter from './AdvancedSearchFilter';
@@ -138,49 +138,11 @@ export default class SongSearchStore
 				songRepo.getOne({ id: entryId, lang: values.languagePreference }),
 		);
 
-		reaction(
-			() => this.advancedFilters.filters.map((filter) => filter.description),
-			this.updateResultsWithTotalCount,
-		);
-		reaction(
-			() => this.artistFilters.filters,
-			this.updateResultsWithTotalCount,
-		);
-		reaction(() => this.afterDate, this.updateResultsWithTotalCount);
-		reaction(() => this.releaseEvent.id, this.updateResultsWithTotalCount);
-		reaction(() => this.minScore, this.updateResultsWithTotalCount);
-		reaction(() => this.onlyRatedSongs, this.updateResultsWithTotalCount);
-		reaction(() => this.parentVersion.id, this.updateResultsWithTotalCount);
 		this.pvPlayerStore = new PVPlayerStore(
 			values,
 			songRepo,
 			userRepo,
 			pvPlayersFactory,
-		);
-		reaction(() => this.pvsOnly, this.updateResultsWithTotalCount);
-		reaction(() => this.since, this.updateResultsWithTotalCount);
-		reaction(() => this.songType, this.updateResultsWithTotalCount);
-		reaction(() => this.sort, this.updateResultsWithTotalCount);
-		reaction(
-			() => this.unifyEntryTypesAndTags,
-			this.updateResultsWithTotalCount,
-		);
-		reaction(() => this.viewMode, this.updateResultsWithTotalCount);
-		reaction(
-			() => this.minBpmFilter.milliBpm,
-			this.updateResultsWithTotalCount,
-		);
-		reaction(
-			() => this.maxBpmFilter.milliBpm,
-			this.updateResultsWithTotalCount,
-		);
-		reaction(
-			() => this.minLengthFilter.length,
-			this.updateResultsWithTotalCount,
-		);
-		reaction(
-			() => this.maxLengthFilter.length,
-			this.updateResultsWithTotalCount,
 		);
 
 		const songsRepoAdapter = new PlayListRepositoryForSongsAdapter(

--- a/VocaDbWeb/Scripts/Stores/Search/TagSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/TagSearchStore.ts
@@ -7,7 +7,7 @@ import { computed, makeObservable, observable } from 'mobx';
 
 import { ICommonSearchStore } from './CommonSearchStore';
 import SearchCategoryBaseStore from './SearchCategoryBaseStore';
-import { SearchRouteParams, SearchType } from './SearchStore';
+import { SearchType } from './SearchStore';
 
 // Corresponds to the TagSortRule enum in C#.
 export enum TagSortRule {
@@ -73,7 +73,7 @@ export default class TagSearchStore extends SearchCategoryBaseStore<TagApiContra
 		'sort',
 	];
 
-	@computed.struct public get routeParams(): SearchRouteParams {
+	@computed.struct public get routeParams(): TagSearchRouteParams {
 		return {
 			searchType: SearchType.Tag,
 			categoryName: this.categoryName,
@@ -83,9 +83,7 @@ export default class TagSearchStore extends SearchCategoryBaseStore<TagApiContra
 			sort: this.sort,
 		};
 	}
-	public set routeParams(value: SearchRouteParams) {
-		if (value.searchType !== SearchType.Tag) return;
-
+	public set routeParams(value: TagSearchRouteParams) {
 		this.categoryName = value.categoryName;
 		this.searchTerm = value.filter ?? '';
 		this.paging.page = value.page ?? 1;

--- a/VocaDbWeb/Scripts/Stores/Search/TagSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/TagSearchStore.ts
@@ -79,7 +79,7 @@ export default class TagSearchStore extends SearchCategoryBaseStore<TagApiContra
 			categoryName: this.categoryName,
 			filter: this.searchTerm,
 			page: this.paging.page,
-			pageSize: this.pageSize,
+			pageSize: this.paging.pageSize,
 			sort: this.sort,
 		};
 	}
@@ -89,7 +89,7 @@ export default class TagSearchStore extends SearchCategoryBaseStore<TagApiContra
 		this.categoryName = value.categoryName;
 		this.searchTerm = value.filter ?? '';
 		this.paging.page = value.page ?? 1;
-		this.pageSize = value.pageSize ?? 10;
+		this.paging.pageSize = value.pageSize ?? 10;
 		this.sort = value.sort ?? TagSortRule.Name;
 	}
 }

--- a/VocaDbWeb/Scripts/Stores/Search/TagSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/TagSearchStore.ts
@@ -3,7 +3,7 @@ import PartialFindResultContract from '@DataContracts/PartialFindResultContract'
 import TagApiContract from '@DataContracts/Tag/TagApiContract';
 import TagRepository from '@Repositories/TagRepository';
 import GlobalValues from '@Shared/GlobalValues';
-import { computed, makeObservable, observable, reaction } from 'mobx';
+import { computed, makeObservable, observable } from 'mobx';
 
 import { ICommonSearchStore } from './CommonSearchStore';
 import SearchCategoryBaseStore from './SearchCategoryBaseStore';
@@ -39,10 +39,6 @@ export default class TagSearchStore extends SearchCategoryBaseStore<TagApiContra
 		super(commonSearchStore);
 
 		makeObservable(this);
-
-		reaction(() => this.allowAliases, this.updateResultsWithTotalCount);
-		reaction(() => this.categoryName, this.updateResultsWithTotalCount);
-		reaction(() => this.sort, this.updateResultsWithTotalCount);
 	}
 
 	public loadResults = (

--- a/VocaDbWeb/Scripts/Stores/Search/TagSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/TagSearchStore.ts
@@ -63,6 +63,16 @@ export default class TagSearchStore extends SearchCategoryBaseStore<TagApiContra
 		});
 	};
 
+	public readonly clearResultsByQueryKeys: (keyof TagSearchRouteParams)[] = [
+		'pageSize',
+		'filter',
+		'searchType',
+
+		// TODO: allowAliases
+		'categoryName',
+		'sort',
+	];
+
 	@computed.struct public get routeParams(): SearchRouteParams {
 		return {
 			searchType: SearchType.Tag,

--- a/VocaDbWeb/Scripts/Stores/Search/TagSearchStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Search/TagSearchStore.ts
@@ -3,10 +3,11 @@ import PartialFindResultContract from '@DataContracts/PartialFindResultContract'
 import TagApiContract from '@DataContracts/Tag/TagApiContract';
 import TagRepository from '@Repositories/TagRepository';
 import GlobalValues from '@Shared/GlobalValues';
-import { makeObservable, observable, reaction } from 'mobx';
+import { computed, makeObservable, observable, reaction } from 'mobx';
 
 import { ICommonSearchStore } from './CommonSearchStore';
 import SearchCategoryBaseStore from './SearchCategoryBaseStore';
+import { SearchRouteParams, SearchType } from './SearchStore';
 
 // Corresponds to the TagSortRule enum in C#.
 export enum TagSortRule {
@@ -14,6 +15,15 @@ export enum TagSortRule {
 	Name = 'Name',
 	AdditionDate = 'AdditionDate',
 	UsageCount = 'UsageCount',
+}
+
+export interface TagSearchRouteParams {
+	categoryName?: string;
+	filter?: string;
+	page?: number;
+	pageSize?: number;
+	searchType?: SearchType.Tag;
+	sort?: TagSortRule;
 }
 
 export default class TagSearchStore extends SearchCategoryBaseStore<TagApiContract> {
@@ -56,4 +66,24 @@ export default class TagSearchStore extends SearchCategoryBaseStore<TagApiContra
 			},
 		});
 	};
+
+	@computed.struct public get routeParams(): SearchRouteParams {
+		return {
+			searchType: SearchType.Tag,
+			categoryName: this.categoryName,
+			filter: this.searchTerm,
+			page: this.paging.page,
+			pageSize: this.pageSize,
+			sort: this.sort,
+		};
+	}
+	public set routeParams(value: SearchRouteParams) {
+		if (value.searchType !== SearchType.Tag) return;
+
+		this.categoryName = value.categoryName;
+		this.searchTerm = value.filter ?? '';
+		this.paging.page = value.page ?? 1;
+		this.pageSize = value.pageSize ?? 10;
+		this.sort = value.sort ?? TagSortRule.Name;
+	}
 }

--- a/VocaDbWeb/Scripts/Stores/Song/PlayList/PlayListStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Song/PlayList/PlayListStore.ts
@@ -47,7 +47,6 @@ export default class PlayListStore {
 	@observable public loading = true; // Currently loading for data
 	@observable public page: ISongForPlayList[] = []; // Current page of items
 	public readonly paging = new ServerSidePagingStore(30); // Paging view model
-	public pauseNotifications = false;
 	public pvServiceIcons: PVServiceIcons;
 
 	public constructor(
@@ -123,6 +122,8 @@ export default class PlayListStore {
 			this.updateResultsWithoutTotalCount();
 		}
 	};
+
+	private pauseNotifications = false;
 
 	@action public updateResults = (
 		clearResults: boolean = true,

--- a/VocaDbWeb/Scripts/Stores/SongList/FeaturedSongListsRouteParams.schema.json
+++ b/VocaDbWeb/Scripts/Stores/SongList/FeaturedSongListsRouteParams.schema.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"properties": {
+		"categoryName": {
+			"enum": ["Concerts", "Nothing", "Other", "Pools", "VocaloidRanking"],
+			"type": "string"
+		},
+		"filter": {
+			"type": "string"
+		},
+		"sort": {
+			"enum": ["CreateDate", "Date", "Name"],
+			"type": "string"
+		},
+		"tagId": {
+			"items": {
+				"type": "number"
+			},
+			"type": "array"
+		}
+	},
+	"type": "object"
+}

--- a/VocaDbWeb/Scripts/Stores/SongList/SongListsBaseStore.ts
+++ b/VocaDbWeb/Scripts/Stores/SongList/SongListsBaseStore.ts
@@ -5,6 +5,7 @@ import GlobalValues from '@Shared/GlobalValues';
 import PagedItemsStore from '@Stores/PagedItemsStore';
 import TagFilter from '@Stores/Search/TagFilter';
 import TagFilters from '@Stores/Search/TagFilters';
+import _ from 'lodash';
 import { action, computed, makeObservable, observable, reaction } from 'mobx';
 import moment from 'moment';
 
@@ -13,6 +14,12 @@ export enum SongListSortRule {
 	Name = 'Name',
 	Date = 'Date',
 	CreateDate = 'CreateDate',
+}
+
+interface SongListsBaseRouteParams {
+	filter?: string;
+	sort?: SongListSortRule;
+	tagId?: number[];
 }
 
 export default abstract class SongListsBaseStore extends PagedItemsStore<SongListContract> {
@@ -37,10 +44,23 @@ export default abstract class SongListsBaseStore extends PagedItemsStore<SongLis
 
 		if (tagIds) this.tagFilters.addTags(tagIds);
 
-		reaction(() => this.query, this.clear);
 		reaction(() => this.showTags, this.clear);
-		reaction(() => this.sort, this.clear);
-		reaction(() => this.tagFilters.tags.map((tag) => tag.id), this.clear);
+	}
+
+	@computed public get tags(): TagFilter[] {
+		return this.tagFilters.tags;
+	}
+	public set tags(value: TagFilter[]) {
+		this.tagFilters.tags = value;
+	}
+
+	@computed public get tagIds(): number[] {
+		return _.map(this.tags, (t) => t.id);
+	}
+	public set tagIds(value: number[]) {
+		// OPTIMIZE
+		this.tagFilters.tags = [];
+		this.tagFilters.addTags(value);
 	}
 
 	@computed public get fields(): string {
@@ -70,4 +90,17 @@ export default abstract class SongListsBaseStore extends PagedItemsStore<SongLis
 	@action public selectTag = (tag: TagBaseContract): void => {
 		this.tagFilters.tags = [TagFilter.fromContract(tag)];
 	};
+
+	@computed.struct public get routeParams(): SongListsBaseRouteParams {
+		return {
+			filter: this.query,
+			sort: this.sort,
+			tagId: this.tagIds,
+		};
+	}
+	public set routeParams(value: SongListsBaseRouteParams) {
+		this.query = value.filter ?? '';
+		this.sort = value.sort || SongListSortRule.Date;
+		this.tagIds = value.tagId ?? [];
+	}
 }

--- a/VocaDbWeb/Scripts/Stores/User/ListUsersRouteParams.schema.json
+++ b/VocaDbWeb/Scripts/Stores/User/ListUsersRouteParams.schema.json
@@ -1,0 +1,39 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"properties": {
+		"disabledUsers": {
+			"type": "boolean"
+		},
+		"filter": {
+			"type": "string"
+		},
+		"groupId": {
+			"enum": [
+				"Admin",
+				"Limited",
+				"Moderator",
+				"Nothing",
+				"Regular",
+				"Trusted"
+			],
+			"type": "string"
+		},
+		"knowsLanguage": {
+			"type": "string"
+		},
+		"onlyVerifiedArtists": {
+			"type": "boolean"
+		},
+		"page": {
+			"type": "number"
+		},
+		"pageSize": {
+			"type": "number"
+		},
+		"sort": {
+			"enum": ["Group", "Name", "RegisterDate"],
+			"type": "string"
+		}
+	},
+	"type": "object"
+}

--- a/VocaDbWeb/Scripts/Stores/User/ListUsersStore.ts
+++ b/VocaDbWeb/Scripts/Stores/User/ListUsersStore.ts
@@ -39,8 +39,7 @@ export default class ListUsersStore
 	@observable public knowsLanguage = '';
 	@observable public onlyVerifiedArtists = false;
 	@observable public page: UserApiContract[] = []; // Current page of items
-	@observable public paging = new ServerSidePagingStore(20); // Paging view model
-	public pauseNotifications = false;
+	public readonly paging = new ServerSidePagingStore(20); // Paging view model
 	@observable public searchTerm = '';
 	@observable public sort = UserSortRule.RegisterDate;
 
@@ -84,6 +83,8 @@ export default class ListUsersStore
 
 	public validateRouteParams = (data: any): data is ListUsersRouteParams =>
 		validate(data);
+
+	private pauseNotifications = false;
 
 	public updateResults = (clearResults: boolean): void => {
 		// Disable duplicate updates

--- a/VocaDbWeb/Scripts/Stores/User/ListUsersStore.ts
+++ b/VocaDbWeb/Scripts/Stores/User/ListUsersStore.ts
@@ -1,7 +1,7 @@
 import UserApiContract from '@DataContracts/User/UserApiContract';
 import UserGroup from '@Models/Users/UserGroup';
 import UserRepository from '@Repositories/UserRepository';
-import IStoreWithRouteParams from '@Stores/IStoreWithRouteParams';
+import IStoreWithUpdateResults from '@Stores/IStoreWithUpdateResults';
 import ServerSidePagingStore from '@Stores/ServerSidePagingStore';
 import { computed, makeObservable, observable, runInAction } from 'mobx';
 
@@ -24,7 +24,7 @@ export interface ListUsersRouteParams {
 }
 
 export default class ListUsersStore
-	implements IStoreWithRouteParams<ListUsersRouteParams> {
+	implements IStoreWithUpdateResults<ListUsersRouteParams> {
 	@observable public disabledUsers = false;
 	@observable public group = UserGroup.Nothing;
 	@observable public loading = false;
@@ -39,6 +39,15 @@ export default class ListUsersStore
 	public constructor(private readonly userRepo: UserRepository) {
 		makeObservable(this);
 	}
+
+	public readonly clearResultsByQueryKeys: (keyof ListUsersRouteParams)[] = [
+		'disabledUsers',
+		'groupId',
+		'knowsLanguage',
+		'onlyVerifiedArtists',
+		'pageSize',
+		'filter',
+	];
 
 	@computed.struct public get routeParams(): ListUsersRouteParams {
 		return {
@@ -63,7 +72,7 @@ export default class ListUsersStore
 		this.sort = value.sort ?? UserSortRule.RegisterDate;
 	}
 
-	private updateResults = (clearResults: boolean): void => {
+	public updateResults = (clearResults: boolean): void => {
 		// Disable duplicate updates
 		if (this.pauseNotifications) return;
 

--- a/VocaDbWeb/Scripts/Stores/User/ListUsersStore.ts
+++ b/VocaDbWeb/Scripts/Stores/User/ListUsersStore.ts
@@ -1,6 +1,7 @@
 import UserApiContract from '@DataContracts/User/UserApiContract';
 import UserGroup from '@Models/Users/UserGroup';
 import UserRepository from '@Repositories/UserRepository';
+import IStoreWithRouteParams from '@Stores/IStoreWithRouteParams';
 import ServerSidePagingStore from '@Stores/ServerSidePagingStore';
 import {
 	computed,
@@ -28,7 +29,8 @@ export interface ListUsersRouteParams {
 	sort?: UserSortRule;
 }
 
-export default class ListUsersStore {
+export default class ListUsersStore
+	implements IStoreWithRouteParams<ListUsersRouteParams> {
 	@observable public disabledUsers = false;
 	@observable public group = UserGroup.Nothing;
 	@observable public loading = false;

--- a/VocaDbWeb/Scripts/Stores/User/ListUsersStore.ts
+++ b/VocaDbWeb/Scripts/Stores/User/ListUsersStore.ts
@@ -3,13 +3,7 @@ import UserGroup from '@Models/Users/UserGroup';
 import UserRepository from '@Repositories/UserRepository';
 import IStoreWithRouteParams from '@Stores/IStoreWithRouteParams';
 import ServerSidePagingStore from '@Stores/ServerSidePagingStore';
-import {
-	computed,
-	makeObservable,
-	observable,
-	reaction,
-	runInAction,
-} from 'mobx';
+import { computed, makeObservable, observable, runInAction } from 'mobx';
 
 // Corresponds to the UserSortRule enum in C#.
 export enum UserSortRule {
@@ -44,17 +38,6 @@ export default class ListUsersStore
 
 	public constructor(private readonly userRepo: UserRepository) {
 		makeObservable(this);
-
-		reaction(() => this.disabledUsers, this.updateResultsWithTotalCount);
-		reaction(() => this.group, this.updateResultsWithTotalCount);
-		reaction(() => this.knowsLanguage, this.updateResultsWithTotalCount);
-		reaction(() => this.onlyVerifiedArtists, this.updateResultsWithTotalCount);
-		reaction(() => this.paging.page, this.updateResultsWithoutTotalCount);
-		reaction(() => this.paging.pageSize, this.updateResultsWithTotalCount);
-		reaction(() => this.searchTerm, this.updateResultsWithTotalCount);
-		reaction(() => this.sort, this.updateResultsWithoutTotalCount);
-
-		this.updateResults(true);
 	}
 
 	@computed.struct public get routeParams(): ListUsersRouteParams {

--- a/VocaDbWeb/Scripts/Stores/User/ListUsersStore.ts
+++ b/VocaDbWeb/Scripts/Stores/User/ListUsersStore.ts
@@ -82,10 +82,8 @@ export default class ListUsersStore
 		this.sort = value.sort ?? UserSortRule.RegisterDate;
 	}
 
-	public validateRouteParams = (data: any): data is ListUsersRouteParams => {
-		if (validate(data)) return true;
-		return false;
-	};
+	public validateRouteParams = (data: any): data is ListUsersRouteParams =>
+		validate(data);
 
 	public updateResults = (clearResults: boolean): void => {
 		// Disable duplicate updates

--- a/VocaDbWeb/Scripts/Stores/User/ListUsersStore.ts
+++ b/VocaDbWeb/Scripts/Stores/User/ListUsersStore.ts
@@ -2,13 +2,30 @@ import UserApiContract from '@DataContracts/User/UserApiContract';
 import UserGroup from '@Models/Users/UserGroup';
 import UserRepository from '@Repositories/UserRepository';
 import ServerSidePagingStore from '@Stores/ServerSidePagingStore';
-import { makeObservable, observable, reaction, runInAction } from 'mobx';
+import {
+	computed,
+	makeObservable,
+	observable,
+	reaction,
+	runInAction,
+} from 'mobx';
 
 // Corresponds to the UserSortRule enum in C#.
 export enum UserSortRule {
 	RegisterDate = 'RegisterDate',
 	Name = 'Name',
 	Group = 'Group',
+}
+
+export interface ListUsersRouteParams {
+	disabledUsers?: boolean;
+	filter?: string;
+	groupId?: UserGroup;
+	knowsLanguage?: string;
+	onlyVerifiedArtists?: boolean;
+	page?: number;
+	pageSize?: number;
+	sort?: UserSortRule;
 }
 
 export default class ListUsersStore {
@@ -36,6 +53,29 @@ export default class ListUsersStore {
 		reaction(() => this.sort, this.updateResultsWithoutTotalCount);
 
 		this.updateResults(true);
+	}
+
+	@computed.struct public get routeParams(): ListUsersRouteParams {
+		return {
+			disabledUsers: this.disabledUsers,
+			filter: this.searchTerm,
+			groupId: this.group,
+			knowsLanguage: this.knowsLanguage,
+			onlyVerifiedArtists: this.onlyVerifiedArtists,
+			page: this.paging.page,
+			pageSize: this.paging.pageSize,
+			sort: this.sort,
+		};
+	}
+	public set routeParams(value: ListUsersRouteParams) {
+		this.disabledUsers = value.disabledUsers ?? false;
+		this.searchTerm = value.filter ?? '';
+		this.group = value.groupId ?? UserGroup.Nothing;
+		this.knowsLanguage = value.knowsLanguage ?? '';
+		this.onlyVerifiedArtists = value.onlyVerifiedArtists ?? false;
+		this.paging.page = value.page ?? 1;
+		this.paging.pageSize = value.pageSize ?? 20;
+		this.sort = value.sort ?? UserSortRule.RegisterDate;
 	}
 
 	private updateResults = (clearResults: boolean): void => {

--- a/VocaDbWeb/Scripts/Stores/User/ListUsersStore.ts
+++ b/VocaDbWeb/Scripts/Stores/User/ListUsersStore.ts
@@ -78,8 +78,6 @@ export default class ListUsersStore
 
 		this.pauseNotifications = true;
 
-		if (clearResults) this.paging.goToFirstPage();
-
 		const pagingProperties = this.paging.getPagingProperties(clearResults);
 		this.userRepo
 			.getList({

--- a/VocaDbWeb/package-lock.json
+++ b/VocaDbWeb/package-lock.json
@@ -6,6 +6,7 @@
         "": {
             "dependencies": {
                 "ajv": "^8.6.2",
+                "ajv-formats": "^2.1.1",
                 "axios": "^0.21.1",
                 "bootstrap-sass": "^2.3.2",
                 "classnames": "^2.3.1",
@@ -3610,6 +3611,22 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
             }
         },
         "node_modules/ajv-keywords": {
@@ -24697,6 +24714,14 @@
                 "json-schema-traverse": "^1.0.0",
                 "require-from-string": "^2.0.2",
                 "uri-js": "^4.2.2"
+            }
+        },
+        "ajv-formats": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+            "requires": {
+                "ajv": "^8.0.0"
             }
         },
         "ajv-keywords": {

--- a/VocaDbWeb/package-lock.json
+++ b/VocaDbWeb/package-lock.json
@@ -5,6 +5,7 @@
     "packages": {
         "": {
             "dependencies": {
+                "ajv": "^8.6.2",
                 "axios": "^0.21.1",
                 "bootstrap-sass": "^2.3.2",
                 "classnames": "^2.3.1",
@@ -23,6 +24,7 @@
                 "mobx": "^6.3.2",
                 "mobx-react-lite": "^3.2.0",
                 "moment": "^2.17.0",
+                "qs": "^6.7.0",
                 "qtip2": "^3.0.3",
                 "react": "^17.0.2",
                 "react-debounce-input": "^3.2.5",
@@ -44,6 +46,7 @@
                 "@types/jquery": "^1.10.8-alpha",
                 "@types/jqueryui": "^1.9.14-alpha",
                 "@types/knockout.punches": "^0.5.33",
+                "@types/qs": "^6.9.7",
                 "@types/react": "^17.0.13",
                 "@types/react-dom": "^17.0.8",
                 "@types/react-transition-group": "^4.4.1",
@@ -1315,6 +1318,22 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
             "version": "12.4.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -1354,6 +1373,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/@eslint/eslintrc/node_modules/resolve-from": {
             "version": "4.0.0",
@@ -2978,6 +3003,12 @@
             "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
             "dev": true
         },
+        "node_modules/@types/qs": {
+            "version": "6.9.7",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+            "dev": true
+        },
         "node_modules/@types/react": {
             "version": "17.0.13",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.13.tgz",
@@ -3567,14 +3598,13 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
+            "version": "8.6.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
+            "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
                 "uri-js": "^4.2.2"
             },
             "funding": {
@@ -5637,6 +5667,22 @@
                 "webpack": "^4.27.0 || ^5.0.0"
             }
         },
+        "node_modules/css-loader/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/css-loader/node_modules/emojis-list": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -5645,6 +5691,12 @@
             "engines": {
                 "node": ">= 4"
             }
+        },
+        "node_modules/css-loader/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/css-loader/node_modules/loader-utils": {
             "version": "2.0.0",
@@ -7412,6 +7464,28 @@
                 "webpack": "^4.0.0 || ^5.0.0"
             }
         },
+        "node_modules/eslint-webpack-plugin/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/eslint-webpack-plugin/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
         "node_modules/eslint-webpack-plugin/node_modules/schema-utils": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
@@ -7437,6 +7511,22 @@
             "dev": true,
             "dependencies": {
                 "@babel/highlight": "^7.10.4"
+            }
+        },
+        "node_modules/eslint/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
             }
         },
         "node_modules/eslint/node_modules/ansi-regex": {
@@ -7559,6 +7649,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/eslint/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/eslint/node_modules/path-key": {
             "version": "3.1.1",
@@ -8265,6 +8361,22 @@
                 "webpack": "^4.0.0 || ^5.0.0"
             }
         },
+        "node_modules/file-loader/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/file-loader/node_modules/emojis-list": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -8273,6 +8385,12 @@
             "engines": {
                 "node": ">= 4"
             }
+        },
+        "node_modules/file-loader/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/file-loader/node_modules/loader-utils": {
             "version": "2.0.0",
@@ -8738,6 +8856,30 @@
                 "node": ">=6"
             }
         },
+        "node_modules/har-validator/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/har-validator/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
+            "optional": true
+        },
         "node_modules/has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -9032,6 +9174,22 @@
                 "webpack": "^4.0.0 || ^5.0.0"
             }
         },
+        "node_modules/html-loader/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/html-loader/node_modules/emojis-list": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -9040,6 +9198,12 @@
             "engines": {
                 "node": ">= 4"
             }
+        },
+        "node_modules/html-loader/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/html-loader/node_modules/loader-utils": {
             "version": "2.0.0",
@@ -12587,10 +12751,9 @@
             "optional": true
         },
         "node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -13717,6 +13880,22 @@
                 "webpack": "^4.4.0 || ^5.0.0"
             }
         },
+        "node_modules/mini-css-extract-plugin/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/mini-css-extract-plugin/node_modules/emojis-list": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -13725,6 +13904,12 @@
             "engines": {
                 "node": ">= 4"
             }
+        },
+        "node_modules/mini-css-extract-plugin/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/mini-css-extract-plugin/node_modules/loader-utils": {
             "version": "2.0.0",
@@ -17085,7 +17270,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -17104,7 +17288,6 @@
             "version": "6.7.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
             "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-            "dev": true,
             "engines": {
                 "node": ">=0.6"
             }
@@ -17812,7 +17995,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -18035,6 +18217,28 @@
             "engines": {
                 "node": ">= 8.9.0"
             }
+        },
+        "node_modules/schema-utils/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/schema-utils/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/screenfull": {
             "version": "5.1.0",
@@ -19035,6 +19239,22 @@
                 "webpack": "^4.0.0 || ^5.0.0"
             }
         },
+        "node_modules/style-loader/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/style-loader/node_modules/emojis-list": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -19043,6 +19263,12 @@
             "engines": {
                 "node": ">= 4"
             }
+        },
+        "node_modules/style-loader/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/style-loader/node_modules/loader-utils": {
             "version": "2.0.0",
@@ -19253,22 +19479,6 @@
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/table/node_modules/ajv": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
-            "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
-            "dev": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
         "node_modules/table/node_modules/ansi-regex": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -19277,12 +19487,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/table/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
         },
         "node_modules/table/node_modules/strip-ansi": {
             "version": "6.0.0",
@@ -19361,6 +19565,28 @@
             "peerDependencies": {
                 "webpack": "^5.1.0"
             }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/terser-webpack-plugin/node_modules/p-limit": {
             "version": "3.1.0",
@@ -20247,7 +20473,6 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-            "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -20749,6 +20974,28 @@
                 "webpack": "^4.0.0 || ^5.0.0"
             }
         },
+        "node_modules/webpack-dev-middleware/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/webpack-dev-middleware/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
         "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
@@ -20816,6 +21063,22 @@
                 }
             }
         },
+        "node_modules/webpack-dev-server/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/webpack-dev-server/node_modules/ansi-regex": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -20833,6 +21096,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/webpack-dev-server/node_modules/schema-utils": {
             "version": "3.0.0",
@@ -20929,6 +21198,22 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/webpack/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/webpack/node_modules/enhanced-resolve": {
             "version": "5.8.2",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
@@ -20941,6 +21226,12 @@
             "engines": {
                 "node": ">=10.13.0"
             }
+        },
+        "node_modules/webpack/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/webpack/node_modules/schema-utils": {
             "version": "3.0.0",
@@ -22538,6 +22829,18 @@
                 "strip-json-comments": "^3.1.1"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "globals": {
                     "version": "12.4.0",
                     "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -22562,6 +22865,12 @@
                         "parent-module": "^1.0.0",
                         "resolve-from": "^4.0.0"
                     }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
                 },
                 "resolve-from": {
                     "version": "4.0.0",
@@ -23910,6 +24219,12 @@
             "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
             "dev": true
         },
+        "@types/qs": {
+            "version": "6.9.7",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+            "dev": true
+        },
         "@types/react": {
             "version": "17.0.13",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.13.tgz",
@@ -24374,14 +24689,13 @@
             }
         },
         "ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
+            "version": "8.6.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
+            "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
             "requires": {
                 "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
                 "uri-js": "^4.2.2"
             }
         },
@@ -26040,10 +26354,28 @@
                 "semver": "^7.3.4"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "emojis-list": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
                     "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
                     "dev": true
                 },
                 "loader-utils": {
@@ -27089,6 +27421,18 @@
                         "@babel/highlight": "^7.10.4"
                     }
                 },
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "ansi-regex": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -27170,6 +27514,12 @@
                         "parent-module": "^1.0.0",
                         "resolve-from": "^4.0.0"
                     }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
                 },
                 "path-key": {
                     "version": "3.1.1",
@@ -27582,6 +27932,24 @@
                 "schema-utils": "^3.0.0"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
+                },
                 "schema-utils": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
@@ -28079,10 +28447,28 @@
                 "schema-utils": "^3.0.0"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "emojis-list": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
                     "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
                     "dev": true
                 },
                 "loader-utils": {
@@ -28436,6 +28822,28 @@
             "requires": {
                 "ajv": "^6.5.5",
                 "har-schema": "^2.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true,
+                    "optional": true
+                }
             }
         },
         "has": {
@@ -28669,10 +29077,28 @@
                 "schema-utils": "^3.0.0"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "emojis-list": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
                     "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
                     "dev": true
                 },
                 "loader-utils": {
@@ -31356,10 +31782,9 @@
             "optional": true
         },
         "json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -32216,10 +32641,28 @@
                 "webpack-sources": "^1.1.0"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "emojis-list": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
                     "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
                     "dev": true
                 },
                 "loader-utils": {
@@ -34774,8 +35217,7 @@
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "q": {
             "version": "1.5.1",
@@ -34786,8 +35228,7 @@
         "qs": {
             "version": "6.7.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-            "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-            "dev": true
+            "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         },
         "qtip2": {
             "version": "3.0.3",
@@ -35332,8 +35773,7 @@
         "require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
         },
         "requires-port": {
             "version": "1.0.0",
@@ -35505,6 +35945,26 @@
                 "@types/json-schema": "^7.0.5",
                 "ajv": "^6.12.4",
                 "ajv-keywords": "^3.5.2"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
+                }
             }
         },
         "screenfull": {
@@ -36359,10 +36819,28 @@
                 "schema-utils": "^3.0.0"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "emojis-list": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
                     "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
                     "dev": true
                 },
                 "loader-utils": {
@@ -36530,28 +37008,10 @@
                 "strip-ansi": "^6.0.0"
             },
             "dependencies": {
-                "ajv": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
-                    "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
-                    "dev": true,
-                    "requires": {
-                        "fast-deep-equal": "^3.1.1",
-                        "json-schema-traverse": "^1.0.0",
-                        "require-from-string": "^2.0.2",
-                        "uri-js": "^4.2.2"
-                    }
-                },
                 "ansi-regex": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
                     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-                    "dev": true
-                },
-                "json-schema-traverse": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
                     "dev": true
                 },
                 "strip-ansi": {
@@ -36614,6 +37074,24 @@
                 "terser": "^5.5.1"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
+                },
                 "p-limit": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -37262,7 +37740,6 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-            "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
             }
@@ -37591,6 +38068,18 @@
                 "webpack-sources": "^2.1.1"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "enhanced-resolve": {
                     "version": "5.8.2",
                     "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
@@ -37600,6 +38089,12 @@
                         "graceful-fs": "^4.2.4",
                         "tapable": "^2.2.0"
                     }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
                 },
                 "schema-utils": {
                     "version": "3.0.0",
@@ -37680,6 +38175,24 @@
                 "schema-utils": "^3.0.0"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
+                },
                 "schema-utils": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
@@ -37728,6 +38241,18 @@
                 "ws": "^7.4.4"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "ansi-regex": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -37738,6 +38263,12 @@
                     "version": "3.0.3",
                     "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
                     "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
                     "dev": true
                 },
                 "schema-utils": {

--- a/VocaDbWeb/package.json
+++ b/VocaDbWeb/package.json
@@ -19,6 +19,7 @@
         "@types/jquery": "^1.10.8-alpha",
         "@types/jqueryui": "^1.9.14-alpha",
         "@types/knockout.punches": "^0.5.33",
+        "@types/qs": "^6.9.7",
         "@types/react": "^17.0.13",
         "@types/react-dom": "^17.0.8",
         "@types/react-transition-group": "^4.4.1",
@@ -50,6 +51,7 @@
         "vue-template-compiler": "^2.6.11"
     },
     "dependencies": {
+        "ajv": "^8.6.2",
         "axios": "^0.21.1",
         "bootstrap-sass": "^2.3.2",
         "classnames": "^2.3.1",
@@ -68,6 +70,7 @@
         "mobx": "^6.3.2",
         "mobx-react-lite": "^3.2.0",
         "moment": "^2.17.0",
+        "qs": "^6.7.0",
         "qtip2": "^3.0.3",
         "react": "^17.0.2",
         "react-debounce-input": "^3.2.5",

--- a/VocaDbWeb/package.json
+++ b/VocaDbWeb/package.json
@@ -52,6 +52,7 @@
     },
     "dependencies": {
         "ajv": "^8.6.2",
+        "ajv-formats": "^2.1.1",
         "axios": "^0.21.1",
         "bootstrap-sass": "^2.3.2",
         "classnames": "^2.3.1",


### PR DESCRIPTION
Closes #163.

## The first attempt

I tried to create two custom hooks:

1. Update the URL whenever the state changes.
2. Update the state whenever the URL changes.

It was difficult to implement this feature only by using custom hooks.

## The second attempt

The most important thing in this implementation was to not update stores directly from the UI. Instead, always set new query params by calling a function. This idea was inspired by React's one-way data flow. See also [Sync queryParameters with Redux state and react router for function components](https://stackoverflow.com/questions/63885459/sync-queryparameters-with-redux-state-and-react-router-for-function-components/64020571#64020571).

1. Handle user input (`onClick`, `onChange` and etc.).
2. Rewrite the URL by calling a function, which uses `useNavigate` from React Router internally.
3. Components re-render.
4. `useEffect` is called.
5. Parse and validate query params by using [qs](https://github.com/ljharb/qs) and [ajv](https://github.com/ajv-validator/ajv).
6. Update the store based on the parsed query params. This is done in a MobX action at once, not one by one.
7. Check if search results should be cleared by comparing the current state with the previous one.
8. Load search results.

However, there were some drawbacks with this implementation.

1. It was slow because all child components were re-rendered whenever the URL (or the state) changes.
2. I had to rewrite the URL by calling a function programmatically, rather than changing an observable in a store, which means we can't take advantage of MobX.

## The third attempt

I was surprised that riipah already implemented this feature on the song rankings page by using [ObservableUrlParamRouter](https://github.com/VocaDB/vocadb/blob/dc352077711421e5d2c07a196aa427cc401b2841/VocaDbWeb/Scripts/Shared/Routing/ObservableUrlParamRouter.ts). The third implementation is based on his idea, and basically does two things as I did in the first attempt:

1. Update the URL whenever the state changes (fast).
2. Update the state whenever the URL changes (slow).

For the first case, it's relatively fast because it only pushes changes to URL (not all child components will be re-rendered). For the second case, it's relatively slow because all child components (except for the ones wrapped with `React.memo`) will be re-rendered. This implementation uses code from the first and second attempts as well. I'd say this is how React Router (React Context) was designed.

I couldn't find a way to push changes to URL without re-rendering, but finally I found [one](https://github.com/vercel/next.js/discussions/18072#discussioncomment-109059). Thanks!

There are still some drawbacks with the current implementation.

1. There are still some overheads when validating the route params (But I'd say ajv is fast enough).
2. The query string is too long. We could omit falsy values from the query string.
3. Artist filters, tag filters and etc. are reloaded every time the back/forward buttons are clicked. We should cache search results somehow.

### How it works

There are three custom hooks: `useStoreWithRouteParams`, `useStoreWithUpdateResults` and `useStoreWithPaging`. These hooks are defined as below:

```ts
const useStoreWithRouteParams = <T>(store: IStoreWithRouteParams<T>): void;
const useStoreWithUpdateResults = <T extends Object>(store: IStoreWithUpdateResults<T>, onClearResults: (popState: boolean) => void): void;
const useStoreWithPaging = <T>(store: IStoreWithPaging<T>): void;
```

#### The useStoreWithRouteParams hook

The `useStoreWithRouteParams` hook updates a store that implements the `IStoreWithRouteParams` interface when a route changes, and vice versa. The `IStoreWithRouteParams` interface is defined as below:

```ts
interface IStoreWithRouteParams<T> {
  routeParams: T;
  popState: boolean;

  validateRouteParams: (data: any): data => T;
}
```

The `popState` property is set by the `useStoreWithRouteParams` hook to prevent adding the previous state to history. The `validateRouteParams` function validates route params and should return true if and only if the passed data is valid. The `routeParams` property gets and sets the state of the store.

> Reactions should be independent: Does your code rely on some other reaction having to run first? If that is the case, you probably either violated the first rule, or the new reaction you are about to create should be merged into the one it is depending upon. MobX does not guarantee the order in which reactions will be run.

Source: https://mobx.js.org/reactions.html

#### The useStoreWithUpdateResults hook

The `useStoreWithUpdateResults` updates search results whenever the `routeParams` property changes. The `IStoreWithUpdateResult` interface is defined as below:

```ts
interface IStoreWithUpdateResults<T> extends IStoreWithRouteParams<T> {
  clearResultsByQueryKeys: string[];

  updateResults: (clearResults: boolean) => void;
}
```

The `useStoreWithUpdateResults` hook determines if search results should be cleared by comparing the current and previous values. If that's the case, the `onClearResults` callback is called.

#### The useStoreWithPaging hook

The `useStoreWithPaging` hook is a helper hook that is composed of the `useStoreWithUpdateResults` and `useStoreWithRouteParams` hooks. The `IStoreWithPaging` interface is defined as below:

```ts
interface IStoreWithPaging<T> extends IStoreWithUpdateResults<T> {
  paging: ServerSidePagingStore;
}
```

#### How to generate schema

We use JSON schema to validate route params. Use `typescript-json-schema project/directory/tsconfig.json TYPE` to generate schema from a TypeScript type. For more information, see https://github.com/YousefED/typescript-json-schema.
