### PR TITLE
Create usePageTracking and useRouteParamsTracking

### DIFF
--- a/VocaDbModel/Utils/AppConfig.cs
+++ b/VocaDbModel/Utils/AppConfig.cs
@@ -162,9 +162,11 @@ namespace VocaDb.Model.Utils
 
 		public static int FilteredArtistId => Val("FilteredArtistId", 0);
 
-		public static string GAAccountId => Val(nameof(GAAccountId));
+#nullable enable
+		public static string? GAAccountId => Val(nameof(GAAccountId));
 
-		public static string GADomain => Val(nameof(GADomain));
+		public static string? GADomain => Val(nameof(GADomain));
+#nullable disable
 
 		public static GlobalLinksSection GetGlobalLinksSection()
 		{

--- a/VocaDbWeb/Models/Shared/GlobalValues.cs
+++ b/VocaDbWeb/Models/Shared/GlobalValues.cs
@@ -32,6 +32,7 @@ namespace VocaDb.Web.Models.Shared
 		public DiscType[] AlbumTypes { get; init; }
 		[JsonProperty(ItemConverterType = typeof(StringEnumConverter))]
 		public ArtistType[] ArtistTypes { get; init; }
+		public string? GAAccountId { get; init; }
 		public string? LockdownMessage { get; init; }
 		[JsonProperty(ItemConverterType = typeof(StringEnumConverter))]
 		public SongType[] SongTypes { get; init; }
@@ -68,6 +69,7 @@ namespace VocaDb.Web.Models.Shared
 		{
 			AlbumTypes = AppConfig.AlbumTypes;
 			ArtistTypes = AppConfig.ArtistTypes;
+			GAAccountId = AppConfig.GAAccountId;
 			LockdownMessage = AppConfig.LockdownMessage;
 			SongTypes = AppConfig.SongTypes;
 			StaticContentHost = AppConfig.StaticContentHost;

--- a/VocaDbWeb/Scripts/App.tsx
+++ b/VocaDbWeb/Scripts/App.tsx
@@ -11,6 +11,7 @@ import HttpClient from '@Shared/HttpClient';
 import UrlMapper from '@Shared/UrlMapper';
 import TopBarStore from '@Stores/TopBarStore';
 import React from 'react';
+import ReactGA from 'react-ga';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import './i18n';
@@ -38,6 +39,10 @@ const userRepo = new UserRepository(httpClient, urlMapper);
 const topBarStore = new TopBarStore(loginManager, entryReportRepo, userRepo);
 
 const App = (): React.ReactElement => {
+	React.useEffect(() => {
+		ReactGA.initialize(vdb.values.gaAccountId);
+	}, []);
+
 	return (
 		<BrowserRouter>
 			<Navbar className="navbar-inverse" fixed="top">

--- a/VocaDbWeb/Scripts/Components/Admin/AdminIndex.tsx
+++ b/VocaDbWeb/Scripts/Components/Admin/AdminIndex.tsx
@@ -1,4 +1,5 @@
 import Layout from '@Components/Shared/Layout';
+import useVocaDbTitle from '@Components/useVocaDbTitle';
 import LoginManager from '@Models/LoginManager';
 import React from 'react';
 import { Link } from 'react-router-dom';
@@ -6,8 +7,12 @@ import { Link } from 'react-router-dom';
 const loginManager = new LoginManager(vdb.values);
 
 const AdminIndex = (): React.ReactElement => {
+	const title = 'Site management'; /* TODO: localize */
+
+	useVocaDbTitle(title, true);
+
 	return (
-		<Layout title="Site management" /* TODO: localize */>
+		<Layout title={title}>
 			<h3>Common tasks{/* TODO: localize */}</h3>
 
 			<p>

--- a/VocaDbWeb/Scripts/Components/Discussion/DiscussionFolders.tsx
+++ b/VocaDbWeb/Scripts/Components/Discussion/DiscussionFolders.tsx
@@ -1,5 +1,7 @@
 import Breadcrumb from '@Bootstrap/Breadcrumb';
+import useRouteParamsTracking from '@Components/useRouteParamsTracking';
 import useStoreWithPaging from '@Components/useStoreWithPaging';
+import useVocaDbTitle from '@Components/useVocaDbTitle';
 import DiscussionIndexStore from '@Stores/Discussion/DiscussionIndexStore';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
@@ -9,34 +11,33 @@ import { Link, useParams } from 'react-router-dom';
 import { DiscussionLayout } from './DiscussionRoutes';
 import ViewFolder from './Partials/ViewFolder';
 
-const useDiscussionIndexStore = (
-	discussionIndexStore: DiscussionIndexStore,
-): void => {
-	const { folderId } = useParams();
-
-	React.useEffect(() => {
-		discussionIndexStore.selectFolderById(Number(folderId));
-	}, [discussionIndexStore, discussionIndexStore.folders, folderId]);
-
-	useStoreWithPaging(discussionIndexStore);
-
-	React.useEffect(() => {
-		discussionIndexStore.updateResults(true);
-	}, [discussionIndexStore, discussionIndexStore.folders, folderId]);
-};
-
 interface DiscussionFoldersProps {
 	discussionIndexStore: DiscussionIndexStore;
 }
 
 const DiscussionFolders = observer(
 	({ discussionIndexStore }: DiscussionFoldersProps): React.ReactElement => {
-		const { t } = useTranslation(['ViewRes.Discussion']);
+		const { t, ready } = useTranslation(['ViewRes.Discussion']);
 
-		useDiscussionIndexStore(discussionIndexStore);
+		const title = t('ViewRes.Discussion:Index.Discussions');
+
+		useVocaDbTitle(title, ready);
+
+		const { folderId } = useParams();
+
+		React.useEffect(() => {
+			discussionIndexStore.selectFolderById(Number(folderId));
+		}, [discussionIndexStore, discussionIndexStore.folders, folderId]);
+
+		useStoreWithPaging(discussionIndexStore);
+		useRouteParamsTracking(discussionIndexStore, ready);
+
+		React.useEffect(() => {
+			discussionIndexStore.updateResults(true);
+		}, [discussionIndexStore, discussionIndexStore.folders, folderId]);
 
 		return (
-			<DiscussionLayout>
+			<DiscussionLayout title={title}>
 				<Breadcrumb>
 					<Breadcrumb.Item linkAs={Link} linkProps={{ to: '/discussion' }}>
 						{t('ViewRes.Discussion:Index.Discussions')}

--- a/VocaDbWeb/Scripts/Components/Discussion/DiscussionIndex.tsx
+++ b/VocaDbWeb/Scripts/Components/Discussion/DiscussionIndex.tsx
@@ -1,7 +1,9 @@
+import useVocaDbTitle from '@Components/useVocaDbTitle';
 import DiscussionIndexStore from '@Stores/Discussion/DiscussionIndexStore';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { DiscussionLayout } from './DiscussionRoutes';
 import ViewFolders from './Partials/ViewFolders';
@@ -12,6 +14,12 @@ interface DiscussionIndexProps {
 
 const DiscussionIndex = observer(
 	({ discussionIndexStore }: DiscussionIndexProps): React.ReactElement => {
+		const { t, ready } = useTranslation(['ViewRes.Discussion']);
+
+		const title = t('ViewRes.Discussion:Index.Discussions');
+
+		useVocaDbTitle(title, ready);
+
 		React.useEffect(() => {
 			runInAction(() => {
 				discussionIndexStore.selectedFolder = undefined;
@@ -20,7 +28,7 @@ const DiscussionIndex = observer(
 		}, [discussionIndexStore]);
 
 		return (
-			<DiscussionLayout>
+			<DiscussionLayout title={title}>
 				<ViewFolders discussionIndexStore={discussionIndexStore} />
 			</DiscussionLayout>
 		);

--- a/VocaDbWeb/Scripts/Components/Discussion/DiscussionRoutes.tsx
+++ b/VocaDbWeb/Scripts/Components/Discussion/DiscussionRoutes.tsx
@@ -6,7 +6,6 @@ import HttpClient from '@Shared/HttpClient';
 import UrlMapper from '@Shared/UrlMapper';
 import DiscussionIndexStore from '@Stores/Discussion/DiscussionIndexStore';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Route, Routes } from 'react-router-dom';
 
 import '../../../wwwroot/Content/Styles/discussions.css';
@@ -17,18 +16,14 @@ const DiscussionTopics = React.lazy(() => import('./DiscussionTopics'));
 
 interface DiscussionLayoutProps {
 	children?: React.ReactNode;
+	title?: string;
 }
 
 export const DiscussionLayout = ({
 	children,
+	title,
 }: DiscussionLayoutProps): React.ReactElement => {
-	const { t } = useTranslation(['ViewRes.Discussion']);
-
-	return (
-		<Layout title={t('ViewRes.Discussion:Index.Discussions')}>
-			{children}
-		</Layout>
-	);
+	return <Layout title={title}>{children}</Layout>;
 };
 
 const loginManager = new LoginManager(vdb.values);

--- a/VocaDbWeb/Scripts/Components/Discussion/DiscussionTopics.tsx
+++ b/VocaDbWeb/Scripts/Components/Discussion/DiscussionTopics.tsx
@@ -1,4 +1,5 @@
 import Breadcrumb from '@Bootstrap/Breadcrumb';
+import useVocaDbTitle from '@Components/useVocaDbTitle';
 import DiscussionIndexStore from '@Stores/Discussion/DiscussionIndexStore';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
@@ -14,7 +15,12 @@ interface DiscussionTopicsProps {
 
 const DiscussionTopics = observer(
 	({ discussionIndexStore }: DiscussionTopicsProps): React.ReactElement => {
-		const { t } = useTranslation(['ViewRes.Discussion']);
+		const { t, ready } = useTranslation(['ViewRes.Discussion']);
+
+		const title = t('ViewRes.Discussion:Index.Discussions');
+
+		useVocaDbTitle(title, ready);
+
 		const { topicId } = useParams();
 
 		React.useEffect(() => {
@@ -22,7 +28,7 @@ const DiscussionTopics = observer(
 		}, [discussionIndexStore, topicId]);
 
 		return (
-			<DiscussionLayout>
+			<DiscussionLayout title={title}>
 				<Breadcrumb>
 					<Breadcrumb.Item
 						linkAs={Link}

--- a/VocaDbWeb/Scripts/Components/Discussion/Partials/ViewTopic.tsx
+++ b/VocaDbWeb/Scripts/Components/Discussion/Partials/ViewTopic.tsx
@@ -2,6 +2,7 @@ import Alert from '@Bootstrap/Alert';
 import Button from '@Bootstrap/Button';
 import CommentKnockout from '@Components/Shared/Partials/Comment/CommentKnockout';
 import EditableComments from '@Components/Shared/Partials/Comment/EditableComments';
+import useRouteParamsTracking from '@Components/useRouteParamsTracking';
 import useStoreWithRouteParams from '@Components/useStoreWithRouteParams';
 import LoginManager from '@Models/LoginManager';
 import DiscussionIndexStore from '@Stores/Discussion/DiscussionIndexStore';
@@ -29,6 +30,7 @@ const ViewTopic = observer(
 		const navigate = useNavigate();
 
 		useStoreWithRouteParams(discussionTopicStore);
+		useRouteParamsTracking(discussionTopicStore, true);
 
 		return (
 			<div>

--- a/VocaDbWeb/Scripts/Components/Search/SearchIndex.tsx
+++ b/VocaDbWeb/Scripts/Components/Search/SearchIndex.tsx
@@ -9,8 +9,10 @@ import {
 	SongSearchDropdown,
 } from '@Components/Shared/Partials/Knockout/SearchDropdown';
 import TagFilters from '@Components/Shared/Partials/Knockout/TagFilters';
+import useRouteParamsTracking from '@Components/useRouteParamsTracking';
 import useScript from '@Components/useScript';
 import useStoreWithPaging from '@Components/useStoreWithPaging';
+import useVocaDbTitle from '@Components/useVocaDbTitle';
 import AlbumRepository from '@Repositories/AlbumRepository';
 import ArtistRepository from '@Repositories/ArtistRepository';
 import EntryRepository from '@Repositories/EntryRepository';
@@ -100,7 +102,10 @@ const SearchIndex = observer(
 			'VocaDb.Web.Resources.Domain',
 		]);
 
+		useVocaDbTitle(undefined, true);
+
 		useStoreWithPaging(searchStore);
+		useRouteParamsTracking(searchStore, true);
 
 		useScript('/Scripts/soundcloud-api.js');
 		useScript('https://www.youtube.com/iframe_api');

--- a/VocaDbWeb/Scripts/Components/Shared/Layout.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/Layout.tsx
@@ -1,6 +1,5 @@
 import Alert from '@Bootstrap/Alert';
 import React from 'react';
-import { useTitle } from 'react-use';
 
 interface LayoutProps {
 	children?: React.ReactNode;
@@ -15,8 +14,6 @@ const Layout = ({
 	title,
 	toolbar,
 }: LayoutProps): React.ReactElement => {
-	useTitle(title ? `${title} - ${vdb.values.siteTitle}` : vdb.values.siteTitle);
-
 	return (
 		<>
 			{/* TODO */}

--- a/VocaDbWeb/Scripts/Components/SongList/SongListFeatured.tsx
+++ b/VocaDbWeb/Scripts/Components/SongList/SongListFeatured.tsx
@@ -2,7 +2,9 @@ import SafeAnchor from '@Bootstrap/SafeAnchor';
 import Layout from '@Components/Shared/Layout';
 import SongListsKnockout from '@Components/Shared/Partials/Song/SongListsKnockout';
 import SongListsFilters from '@Components/Shared/Partials/SongListsFilters';
+import useRouteParamsTracking from '@Components/useRouteParamsTracking';
 import useStoreWithUpdateResults from '@Components/useStoreWithUpdateResults';
+import useVocaDbTitle from '@Components/useVocaDbTitle';
 import JQueryUIButton from '@JQueryUI/JQueryUIButton';
 import LoginManager from '@Models/LoginManager';
 import SongListRepository from '@Repositories/SongListRepository';
@@ -37,18 +39,23 @@ const featuredSongListsStore = new FeaturedSongListsStore(
 
 const SongListFeatured = observer(
 	(): React.ReactElement => {
-		const { t } = useTranslation([
+		const { t, ready } = useTranslation([
 			'Resources',
 			'ViewRes',
 			'ViewRes.SongList',
 			'ViewRes.User',
 		]);
 
+		const title = t('ViewRes:Shared.FeaturedSongLists');
+
+		useVocaDbTitle(title, ready);
+
 		useStoreWithUpdateResults(featuredSongListsStore);
+		useRouteParamsTracking(featuredSongListsStore, ready);
 
 		return (
 			<Layout
-				title={t('ViewRes:Shared.FeaturedSongLists')}
+				title={title}
 				toolbar={
 					<>
 						{loginManager.canEditFeaturedLists && (

--- a/VocaDbWeb/Scripts/Components/Stats/StatsIndex.tsx
+++ b/VocaDbWeb/Scripts/Components/Stats/StatsIndex.tsx
@@ -1,4 +1,5 @@
 import Layout from '@Components/Shared/Layout';
+import useVocaDbTitle from '@Components/useVocaDbTitle';
 import HttpClient from '@Shared/HttpClient';
 import StatsStore from '@Stores/StatsStore';
 import Highcharts from 'highcharts';
@@ -13,8 +14,12 @@ const statsStore = new StatsStore(httpClient);
 
 const StatsIndex = observer(
 	(): React.ReactElement => {
+		const title = 'Statistics / Reports'; /* TODO: localize */
+
+		useVocaDbTitle(title, true);
+
 		return (
-			<Layout title="Statistics / Reports" /* TODO: localize */>
+			<Layout title={title}>
 				<select
 					value={JSON.stringify(statsStore.selectedReport)}
 					onChange={(e): void =>

--- a/VocaDbWeb/Scripts/Components/User/UserIndex.tsx
+++ b/VocaDbWeb/Scripts/Components/User/UserIndex.tsx
@@ -1,5 +1,7 @@
 import Layout from '@Components/Shared/Layout';
+import useRouteParamsTracking from '@Components/useRouteParamsTracking';
 import useStoreWithPaging from '@Components/useStoreWithPaging';
+import useVocaDbTitle from '@Components/useVocaDbTitle';
 import UserRepository from '@Repositories/UserRepository';
 import HttpClient from '@Shared/HttpClient';
 import UrlMapper from '@Shared/UrlMapper';
@@ -15,12 +17,17 @@ const userRepo = new UserRepository(httpClient, urlMapper);
 const listUsersStore = new ListUsersStore(userRepo);
 
 const UserIndex = (): React.ReactElement => {
-	const { t } = useTranslation(['ViewRes']);
+	const { t, ready } = useTranslation(['ViewRes']);
+
+	const title = t('ViewRes:Shared.Users');
+
+	useVocaDbTitle(title, ready);
 
 	useStoreWithPaging(listUsersStore);
+	useRouteParamsTracking(listUsersStore, ready);
 
 	return (
-		<Layout title={t('ViewRes:Shared.Users')}>
+		<Layout title={title}>
 			<ListUsers listUsersStore={listUsersStore} />
 		</Layout>
 	);

--- a/VocaDbWeb/Scripts/Components/usePageTracking.ts
+++ b/VocaDbWeb/Scripts/Components/usePageTracking.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactGA from 'react-ga';
+import { useLocation } from 'react-router-dom';
+
+// Captures pageviews as a new page is loaded.
+// The call to usePageTracking must go after useTitle.
+// Set ready to false while translations are not yet loaded.
+// This prevents Google Analytics from using an incomplete page title (e.g. `Index.Discussions - Vocaloid Database`).
+const usePageTracking = (ready: boolean): void => {
+	const location = useLocation();
+
+	React.useEffect(() => {
+		if (ready) ReactGA.pageview(`${location.pathname}${location.search}`);
+	}, [ready, location]);
+};
+
+export default usePageTracking;

--- a/VocaDbWeb/Scripts/Components/useRouteParamsTracking.ts
+++ b/VocaDbWeb/Scripts/Components/useRouteParamsTracking.ts
@@ -1,0 +1,29 @@
+import IStoreWithRouteParams from '@Stores/IStoreWithRouteParams';
+import { reaction } from 'mobx';
+import React from 'react';
+import ReactGA from 'react-ga';
+
+// Captures pageviews as the query string changes.
+// The call to useRouteParamsTracking must go after useStoreWithRouteParams, useStoreWithUpdateResults or useStoreWithPaging.
+// Set ready to false while translations are not yet loaded.
+// This prevents Google Analytics from using an incomplete page title (e.g. `Index.Discussions - Vocaloid Database`).
+const useRouteParamsTracking = <T>(
+	store: IStoreWithRouteParams<T>,
+	ready: boolean,
+): void => {
+	React.useEffect(() => {
+		// Returns the disposer.
+		return reaction(
+			() => store.routeParams,
+			() => {
+				if (ready && !store.popState) {
+					ReactGA.pageview(
+						`${window.location.pathname}${window.location.search}`,
+					);
+				}
+			},
+		);
+	}, [store, ready]);
+};
+
+export default useRouteParamsTracking;

--- a/VocaDbWeb/Scripts/Components/useStoreWithPaging.ts
+++ b/VocaDbWeb/Scripts/Components/useStoreWithPaging.ts
@@ -12,7 +12,6 @@ const useStoreWithPaging = <T>(store: IStoreWithPaging<T>): void => {
 		[store],
 	);
 
-	// `useStoreWithUpdateResults` must be called before `useStoreWithRouteParams` because the former may change `routeParams` based on `clearResultsByQueryKeys`.
 	useStoreWithUpdateResults(store, handleClearResults);
 };
 

--- a/VocaDbWeb/Scripts/Components/useStoreWithUpdateResults.ts
+++ b/VocaDbWeb/Scripts/Components/useStoreWithUpdateResults.ts
@@ -11,6 +11,7 @@ const useStoreWithUpdateResults = <T extends Object>(
 	// Called when search results should be cleared.
 	onClearResults?: (popState: boolean) => void,
 ): void => {
+	// This must be called before `useStoreWithRouteParams` because this may change `routeParams` based on `clearResultsByQueryKeys`.
 	React.useEffect(() => {
 		// Returns the disposer.
 		return reaction(

--- a/VocaDbWeb/Scripts/Components/useVocaDbTitle.ts
+++ b/VocaDbWeb/Scripts/Components/useVocaDbTitle.ts
@@ -1,0 +1,13 @@
+import { useTitle } from 'react-use';
+
+import usePageTracking from './usePageTracking';
+
+const useVocaDbTitle = (title: string | undefined, ready: boolean): void => {
+	useTitle(
+		title ? `${title} - ${vdb.values.siteTitle}` : `${vdb.values.siteTitle}`,
+	);
+
+	usePageTracking(ready);
+};
+
+export default useVocaDbTitle;

--- a/VocaDbWeb/Scripts/Shared/GlobalValues.ts
+++ b/VocaDbWeb/Scripts/Shared/GlobalValues.ts
@@ -11,6 +11,7 @@ interface MenuPageLink {
 export default interface GlobalValues {
 	albumTypes: string /* TODO: enum AlbumType */[];
 	artistTypes: string /* TODO: enum ArtistType */[];
+	gaAccountId: string;
 	lockdownMessage?: string;
 	songTypes: string /* TODO: enum SongType */[];
 	staticContentHost: string;

--- a/VocaDbWeb/Views/React/Index.cshtml
+++ b/VocaDbWeb/Views/React/Index.cshtml
@@ -30,8 +30,6 @@
 	<link href="@Url.Content("~/Content/themes/redmond/jquery-ui-1.10.1.custom.min.css")" rel="stylesheet" type="text/css" />
 	<link href="@Url.Content("~/Scripts/qTip/jquery.qtip.css")" rel="stylesheet" type="text/css" />
 	<link rel="search" type="application/opensearchdescription+xml" title="@BrandableStrings.SiteName" href="@Config.SiteSettings.OpenSearchPath" />
-
-	<partial name="Partials/_GoogleAnalytics" />
 </head>
 <body class="vdb">
 	<div id="app"></div>

--- a/VocaDbWeb/package-lock.json
+++ b/VocaDbWeb/package-lock.json
@@ -30,6 +30,7 @@
                 "react": "^17.0.2",
                 "react-debounce-input": "^3.2.5",
                 "react-dom": "^17.0.2",
+                "react-ga": "^3.3.0",
                 "react-i18next": "^11.11.0",
                 "react-markdown": "^6.0.2",
                 "react-overlays": "^5.1.0",
@@ -17443,6 +17444,15 @@
             },
             "peerDependencies": {
                 "react": "17.0.2"
+            }
+        },
+        "node_modules/react-ga": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz",
+            "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==",
+            "peerDependencies": {
+                "prop-types": "^15.6.0",
+                "react": "^15.6.2 || ^16.0 || ^17"
             }
         },
         "node_modules/react-i18next": {
@@ -35354,6 +35364,12 @@
                 "object-assign": "^4.1.1",
                 "scheduler": "^0.20.2"
             }
+        },
+        "react-ga": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz",
+            "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==",
+            "requires": {}
         },
         "react-i18next": {
             "version": "11.11.0",

--- a/VocaDbWeb/package.json
+++ b/VocaDbWeb/package.json
@@ -76,6 +76,7 @@
         "react": "^17.0.2",
         "react-debounce-input": "^3.2.5",
         "react-dom": "^17.0.2",
+        "react-ga": "^3.3.0",
         "react-i18next": "^11.11.0",
         "react-markdown": "^6.0.2",
         "react-overlays": "^5.1.0",


### PR DESCRIPTION
Closes #971.

Use the `usePageTracking` and `useRouteParamsTracking` hooks so that pageviews can be captured manually. Set `ready` to `false` while translations are not yet loaded. This prevents Google Analytics from using an incomplete page title (e.g. `Index.Discussions - Vocaloid Database`).