### PR TITLE
Add GetDetails to SongListApiController

### DIFF
--- a/VocaDbWeb/Controllers/Api/SongListApiController.cs
+++ b/VocaDbWeb/Controllers/Api/SongListApiController.cs
@@ -282,5 +282,11 @@ namespace VocaDb.Web.Controllers.Api
 		[HttpPost("{listId:int}/comments")]
 		[Authorize]
 		public CommentForApiContract PostNewComment(int listId, CommentForApiContract contract) => _queries.CreateComment(listId, contract);
+
+#nullable enable
+		[HttpGet("{id:int}/details")]
+		[ApiExplorerSettings(IgnoreApi = true)]
+		public SongListForApiContract GetDetails(int id) => _queries.GetDetails(id);
+#nullable disable
 	}
 }


### PR DESCRIPTION
Adds the `/api/songLists/{id:int}/details` endpoint, which will be used on the song list details page. We use the `/details` route for consistency with other endpoints (e.g. `/api/artists/{id:int}/details`, `/api/songs/{id:int}/details` and etc.).