### PR TITLE
Fix XmlHelperTests

### DIFF
--- a/Tests/Helpers/XmlHelperTests.cs
+++ b/Tests/Helpers/XmlHelperTests.cs
@@ -79,9 +79,7 @@ namespace VocaDb.Tests.Helpers
 
 			album.Description.IsNormalized().Should().BeTrue();
 
-			var res = SerializeToObjectAndBack(album);
-
-			res.Description.Should().Be(name, "string is intact");
+			this.Invoking(_ => SerializeToObjectAndBack(album)).Should().Throw<InvalidOperationException>();
 		}
 
 		[TestMethod]
@@ -92,9 +90,7 @@ namespace VocaDb.Tests.Helpers
 
 			album.Description.IsNormalized().Should().BeTrue();
 
-			var res = SerializeToObjectAndBack(album);
-
-			res.Description.Should().Be(name, "string is intact");
+			this.Invoking(_ => SerializeToObjectAndBack(album)).Should().Throw<InvalidOperationException>();
 		}
 	}
 }


### PR DESCRIPTION
After updating to .NET 6, the `System.Xml.Serialization.XmlSerializer.Serialize` method throws an `InvalidOperationException` if an invalid character is included. Were there any breaking changes in XmlSerializer, or is this something related to Unicode stuff? I couldn't find any documentation about that. Anyway, I don't see much benefit of allowing invalid characters.