### PR TITLE
Create AntiforgeryApiController

### DIFF
--- a/VocaDbWeb/Controllers/Api/AntiforgeryApiController.cs
+++ b/VocaDbWeb/Controllers/Api/AntiforgeryApiController.cs
@@ -19,6 +19,9 @@ public class AntiforgeryApiController : ApiController
 		_antiforgery = antiforgery;
 	}
 
+	// The API server must have CORS set to allow only trusted sites.
+	// This is to prevent third-party AJAX requests from getting hold of a CSRF token.
+	// See also https://michaelzanggl.com/articles/csrf-tokens-for-spas/.
 	[HttpGet("token")]
 	[Authorize]
 	[EnableCors(AuthenticationConstants.AuthenticatedCorsApiPolicy)]

--- a/VocaDbWeb/Controllers/Api/AntiforgeryApiController.cs
+++ b/VocaDbWeb/Controllers/Api/AntiforgeryApiController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Mvc;
+using VocaDb.Web.Code.Security;
+using ApiController = Microsoft.AspNetCore.Mvc.ControllerBase;
+
+namespace VocaDb.Web.Controllers.Api;
+
+[EnableCors(AuthenticationConstants.WebApiCorsPolicy)]
+[Route("api/antiforgery")]
+[ApiController]
+public class AntiforgeryApiController : ApiController
+{
+	private readonly IAntiforgery _antiforgery;
+
+	public AntiforgeryApiController(IAntiforgery antiforgery)
+	{
+		_antiforgery = antiforgery;
+	}
+
+	[HttpGet("token")]
+	[Authorize]
+	[EnableCors(AuthenticationConstants.AuthenticatedCorsApiPolicy)]
+	[IgnoreAntiforgeryToken]
+	[ApiExplorerSettings(IgnoreApi = true)]
+	public IActionResult GetToken()
+	{
+		// Code from: https://docs.microsoft.com/en-us/aspnet/core/security/anti-request-forgery?view=aspnetcore-6.0#javascript-1.
+		var tokenSet = _antiforgery.GetAndStoreTokens(HttpContext);
+		Response.Cookies.Append("XSRF-TOKEN", tokenSet.RequestToken!, new CookieOptions { HttpOnly = false });
+
+		return NoContent();
+	}
+}

--- a/VocaDbWeb/Models/Shared/GlobalValues.cs
+++ b/VocaDbWeb/Models/Shared/GlobalValues.cs
@@ -72,8 +72,6 @@ namespace VocaDb.Web.Models.Shared
 		public MenuPageLink[] SmallBanners { get; init; }
 		public MenuPageLink[] SocialLinks { get; init; }
 
-		public string? RequestToken { get; init; }
-
 		public GlobalValues(VocaDbPage model)
 		{
 			AllowCustomArtistName = AppConfig.AllowCustomArtistName;

--- a/VocaDbWeb/Scripts/Pages/Album/AlbumCreate.tsx
+++ b/VocaDbWeb/Scripts/Pages/Album/AlbumCreate.tsx
@@ -18,6 +18,7 @@ import { ArtistRepository } from '@/Repositories/ArtistRepository';
 import { HttpClient } from '@/Shared/HttpClient';
 import { UrlMapper } from '@/Shared/UrlMapper';
 import { AlbumCreateStore } from '@/Stores/Album/AlbumCreateStore';
+import { getReasonPhrase } from 'http-status-codes';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
@@ -73,8 +74,8 @@ const AlbumCreateLayout = observer(
 							navigate(`/Album/Edit/${id}`);
 						} catch (error: any) {
 							showErrorMessage(
-								error.response && error.response.statusText
-									? error.response.statusText
+								error.response && error.response.status
+									? getReasonPhrase(error.response.status)
 									: t('ViewRes.Album:Create.UnableToCreateAlbum'),
 							);
 

--- a/VocaDbWeb/Scripts/Pages/Album/AlbumCreate.tsx
+++ b/VocaDbWeb/Scripts/Pages/Album/AlbumCreate.tsx
@@ -13,8 +13,10 @@ import { showErrorMessage } from '@/Components/ui';
 import { useVocaDbTitle } from '@/Components/useVocaDbTitle';
 import { AlbumType } from '@/Models/Albums/AlbumType';
 import { AlbumRepository } from '@/Repositories/AlbumRepository';
+import { AntiforgeryRepository } from '@/Repositories/AntiforgeryRepository';
 import { ArtistRepository } from '@/Repositories/ArtistRepository';
 import { HttpClient } from '@/Shared/HttpClient';
+import { UrlMapper } from '@/Shared/UrlMapper';
 import { AlbumCreateStore } from '@/Stores/Album/AlbumCreateStore';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
@@ -23,7 +25,9 @@ import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
 
 const httpClient = new HttpClient();
+const urlMapper = new UrlMapper(vdb.values.baseAddress);
 
+const antiforgeryRepo = new AntiforgeryRepository(httpClient, urlMapper);
 const albumRepo = new AlbumRepository(httpClient, vdb.values.baseAddress);
 const artistRepo = new ArtistRepository(httpClient, vdb.values.baseAddress);
 
@@ -62,7 +66,9 @@ const AlbumCreateLayout = observer(
 						e.preventDefault();
 
 						try {
-							const id = await albumCreateStore.submit();
+							const requestToken = await antiforgeryRepo.getToken();
+
+							const id = await albumCreateStore.submit(requestToken);
 
 							navigate(`/Album/Edit/${id}`);
 						} catch (e) {

--- a/VocaDbWeb/Scripts/Pages/Album/AlbumCreate.tsx
+++ b/VocaDbWeb/Scripts/Pages/Album/AlbumCreate.tsx
@@ -72,7 +72,11 @@ const AlbumCreateLayout = observer(
 
 							navigate(`/Album/Edit/${id}`);
 						} catch (error: any) {
-							showErrorMessage(t('ViewRes.Album:Create.UnableToCreateAlbum'));
+							showErrorMessage(
+								error.response && error.response.statusText
+									? error.response.statusText
+									: t('ViewRes.Album:Create.UnableToCreateAlbum'),
+							);
 
 							throw e;
 						}

--- a/VocaDbWeb/Scripts/Pages/Album/AlbumCreate.tsx
+++ b/VocaDbWeb/Scripts/Pages/Album/AlbumCreate.tsx
@@ -71,7 +71,7 @@ const AlbumCreateLayout = observer(
 							const id = await albumCreateStore.submit(requestToken);
 
 							navigate(`/Album/Edit/${id}`);
-						} catch (e) {
+						} catch (error: any) {
 							showErrorMessage(t('ViewRes.Album:Create.UnableToCreateAlbum'));
 
 							throw e;

--- a/VocaDbWeb/Scripts/Pages/Album/AlbumEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Album/AlbumEdit.tsx
@@ -46,6 +46,7 @@ import ArtistForAlbumEdit from '@/Pages/Album/Partials/ArtistForAlbumEdit';
 import SongInAlbumEdit from '@/Pages/Album/Partials/SongInAlbumEdit';
 import TrackProperties from '@/Pages/Album/Partials/TrackProperties';
 import { AlbumRepository } from '@/Repositories/AlbumRepository';
+import { AntiforgeryRepository } from '@/Repositories/AntiforgeryRepository';
 import { ArtistRepository } from '@/Repositories/ArtistRepository';
 import { PVRepository } from '@/Repositories/PVRepository';
 import { ReleaseEventRepository } from '@/Repositories/ReleaseEventRepository';
@@ -67,6 +68,7 @@ const loginManager = new LoginManager(vdb.values);
 const httpClient = new HttpClient();
 const urlMapper = new UrlMapper(vdb.values.baseAddress);
 
+const antiforgeryRepo = new AntiforgeryRepository(httpClient, urlMapper);
 const albumRepo = new AlbumRepository(httpClient, vdb.values.baseAddress);
 const songRepo = new SongRepository(httpClient, vdb.values.baseAddress);
 const artistRepo = new ArtistRepository(httpClient, vdb.values.baseAddress);
@@ -952,6 +954,8 @@ const AlbumEditLayout = observer(
 						e.preventDefault();
 
 						try {
+							const requestToken = await antiforgeryRepo.getToken();
+
 							const coverPicUpload =
 								coverPicUploadRef.current.files?.item(0) ?? undefined;
 
@@ -965,6 +969,7 @@ const AlbumEditLayout = observer(
 								.value();
 
 							const id = await albumEditStore.submit(
+								requestToken,
 								coverPicUpload,
 								pictureUpload,
 							);

--- a/VocaDbWeb/Scripts/Pages/Album/AlbumEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Album/AlbumEdit.tsx
@@ -55,6 +55,7 @@ import { EntryUrlMapper } from '@/Shared/EntryUrlMapper';
 import { HttpClient } from '@/Shared/HttpClient';
 import { UrlMapper } from '@/Shared/UrlMapper';
 import { AlbumEditStore } from '@/Stores/Album/AlbumEditStore';
+import { getReasonPhrase } from 'http-status-codes';
 import _ from 'lodash';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
@@ -977,8 +978,8 @@ const AlbumEditLayout = observer(
 							navigate(EntryUrlMapper.details(EntryType.Album, id));
 						} catch (error: any) {
 							showErrorMessage(
-								error.response && error.response.statusText
-									? error.response.statusText
+								error.response && error.response.status
+									? getReasonPhrase(error.response.status)
 									: 'Unable to save properties.' /* TODO: localize */,
 							);
 

--- a/VocaDbWeb/Scripts/Pages/Album/AlbumEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Album/AlbumEdit.tsx
@@ -975,7 +975,7 @@ const AlbumEditLayout = observer(
 							);
 
 							navigate(EntryUrlMapper.details(EntryType.Album, id));
-						} catch (e) {
+						} catch (error: any) {
 							showErrorMessage(
 								'Unable to save properties.' /* TODO: localize */,
 							);

--- a/VocaDbWeb/Scripts/Pages/Album/AlbumEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Album/AlbumEdit.tsx
@@ -977,7 +977,9 @@ const AlbumEditLayout = observer(
 							navigate(EntryUrlMapper.details(EntryType.Album, id));
 						} catch (error: any) {
 							showErrorMessage(
-								'Unable to save properties.' /* TODO: localize */,
+								error.response && error.response.statusText
+									? error.response.statusText
+									: 'Unable to save properties.' /* TODO: localize */,
 							);
 
 							throw e;

--- a/VocaDbWeb/Scripts/Pages/Artist/ArtistCreate.tsx
+++ b/VocaDbWeb/Scripts/Pages/Artist/ArtistCreate.tsx
@@ -85,7 +85,7 @@ const ArtistCreateLayout = observer(
 							);
 
 							navigate(`/Artist/Edit/${id}`);
-						} catch (e) {
+						} catch (error: any) {
 							showErrorMessage(t('ViewRes.Artist:Create.UnableToCreateArtist'));
 
 							throw e;

--- a/VocaDbWeb/Scripts/Pages/Artist/ArtistCreate.tsx
+++ b/VocaDbWeb/Scripts/Pages/Artist/ArtistCreate.tsx
@@ -12,9 +12,11 @@ import { useVocaDbTitle } from '@/Components/useVocaDbTitle';
 import { ImageHelper } from '@/Helpers/ImageHelper';
 import { ArtistType } from '@/Models/Artists/ArtistType';
 import { WebLinkCategory } from '@/Models/WebLinkCategory';
+import { AntiforgeryRepository } from '@/Repositories/AntiforgeryRepository';
 import { ArtistRepository } from '@/Repositories/ArtistRepository';
 import { TagRepository } from '@/Repositories/TagRepository';
 import { HttpClient } from '@/Shared/HttpClient';
+import { UrlMapper } from '@/Shared/UrlMapper';
 import { ArtistCreateStore } from '@/Stores/Artist/ArtistCreateStore';
 import classNames from 'classnames';
 import _ from 'lodash';
@@ -25,7 +27,9 @@ import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
 
 const httpClient = new HttpClient();
+const urlMapper = new UrlMapper(vdb.values.baseAddress);
 
+const antiforgeryRepo = new AntiforgeryRepository(httpClient, urlMapper);
 const artistRepo = new ArtistRepository(httpClient, vdb.values.baseAddress);
 const tagRepo = new TagRepository(httpClient, vdb.values.baseAddress);
 
@@ -70,10 +74,15 @@ const ArtistCreateLayout = observer(
 						e.preventDefault();
 
 						try {
+							const requestToken = await antiforgeryRepo.getToken();
+
 							const pictureUpload =
 								pictureUploadRef.current.files?.item(0) ?? undefined;
 
-							const id = await artistCreateStore.submit(pictureUpload);
+							const id = await artistCreateStore.submit(
+								requestToken,
+								pictureUpload,
+							);
 
 							navigate(`/Artist/Edit/${id}`);
 						} catch (e) {

--- a/VocaDbWeb/Scripts/Pages/Artist/ArtistCreate.tsx
+++ b/VocaDbWeb/Scripts/Pages/Artist/ArtistCreate.tsx
@@ -19,6 +19,7 @@ import { HttpClient } from '@/Shared/HttpClient';
 import { UrlMapper } from '@/Shared/UrlMapper';
 import { ArtistCreateStore } from '@/Stores/Artist/ArtistCreateStore';
 import classNames from 'classnames';
+import { getReasonPhrase } from 'http-status-codes';
 import _ from 'lodash';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
@@ -87,8 +88,8 @@ const ArtistCreateLayout = observer(
 							navigate(`/Artist/Edit/${id}`);
 						} catch (error: any) {
 							showErrorMessage(
-								error.response && error.response.statusText
-									? error.response.statusText
+								error.response && error.response.status
+									? getReasonPhrase(error.response.status)
 									: t('ViewRes.Artist:Create.UnableToCreateArtist'),
 							);
 

--- a/VocaDbWeb/Scripts/Pages/Artist/ArtistCreate.tsx
+++ b/VocaDbWeb/Scripts/Pages/Artist/ArtistCreate.tsx
@@ -86,7 +86,11 @@ const ArtistCreateLayout = observer(
 
 							navigate(`/Artist/Edit/${id}`);
 						} catch (error: any) {
-							showErrorMessage(t('ViewRes.Artist:Create.UnableToCreateArtist'));
+							showErrorMessage(
+								error.response && error.response.statusText
+									? error.response.statusText
+									: t('ViewRes.Artist:Create.UnableToCreateArtist'),
+							);
 
 							throw e;
 						}

--- a/VocaDbWeb/Scripts/Pages/Artist/ArtistEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Artist/ArtistEdit.tsx
@@ -43,6 +43,7 @@ import { EntryUrlMapper } from '@/Shared/EntryUrlMapper';
 import { HttpClient } from '@/Shared/HttpClient';
 import { UrlMapper } from '@/Shared/UrlMapper';
 import { ArtistEditStore } from '@/Stores/Artist/ArtistEditStore';
+import { getReasonPhrase } from 'http-status-codes';
 import _ from 'lodash';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
@@ -674,8 +675,8 @@ const ArtistEditLayout = observer(
 							navigate(EntryUrlMapper.details(EntryType.Artist, id));
 						} catch (error: any) {
 							showErrorMessage(
-								error.response && error.response.statusText
-									? error.response.statusText
+								error.response && error.response.status
+									? getReasonPhrase(error.response.status)
 									: 'Unable to save properties.' /* TODO: localize */,
 							);
 

--- a/VocaDbWeb/Scripts/Pages/Artist/ArtistEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Artist/ArtistEdit.tsx
@@ -672,7 +672,7 @@ const ArtistEditLayout = observer(
 							);
 
 							navigate(EntryUrlMapper.details(EntryType.Artist, id));
-						} catch (e) {
+						} catch (error: any) {
 							showErrorMessage(
 								'Unable to save properties.' /* TODO: localize */,
 							);

--- a/VocaDbWeb/Scripts/Pages/Artist/ArtistEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Artist/ArtistEdit.tsx
@@ -37,6 +37,7 @@ import { ArtistType } from '@/Models/Artists/ArtistType';
 import { EntryStatus } from '@/Models/EntryStatus';
 import { EntryType } from '@/Models/EntryType';
 import { LoginManager } from '@/Models/LoginManager';
+import { AntiforgeryRepository } from '@/Repositories/AntiforgeryRepository';
 import { ArtistRepository } from '@/Repositories/ArtistRepository';
 import { EntryUrlMapper } from '@/Shared/EntryUrlMapper';
 import { HttpClient } from '@/Shared/HttpClient';
@@ -54,6 +55,7 @@ const loginManager = new LoginManager(vdb.values);
 const httpClient = new HttpClient();
 const urlMapper = new UrlMapper(vdb.values.baseAddress);
 
+const antiforgeryRepo = new AntiforgeryRepository(httpClient, urlMapper);
 const artistRepo = new ArtistRepository(httpClient, vdb.values.baseAddress);
 
 interface BasicInfoTabContentProps {
@@ -649,6 +651,8 @@ const ArtistEditLayout = observer(
 						e.preventDefault();
 
 						try {
+							const requestToken = await antiforgeryRepo.getToken();
+
 							const coverPicUpload =
 								coverPicUploadRef.current.files?.item(0) ?? undefined;
 
@@ -662,6 +666,7 @@ const ArtistEditLayout = observer(
 								.value();
 
 							const id = await artistEditStore.submit(
+								requestToken,
 								coverPicUpload,
 								pictureUpload,
 							);

--- a/VocaDbWeb/Scripts/Pages/Artist/ArtistEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Artist/ArtistEdit.tsx
@@ -674,7 +674,9 @@ const ArtistEditLayout = observer(
 							navigate(EntryUrlMapper.details(EntryType.Artist, id));
 						} catch (error: any) {
 							showErrorMessage(
-								'Unable to save properties.' /* TODO: localize */,
+								error.response && error.response.statusText
+									? error.response.statusText
+									: 'Unable to save properties.' /* TODO: localize */,
 							);
 
 							throw e;

--- a/VocaDbWeb/Scripts/Pages/Event/EventEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Event/EventEdit.tsx
@@ -50,6 +50,7 @@ import { EntryUrlMapper } from '@/Shared/EntryUrlMapper';
 import { HttpClient } from '@/Shared/HttpClient';
 import { UrlMapper } from '@/Shared/UrlMapper';
 import { ReleaseEventEditStore } from '@/Stores/ReleaseEvent/ReleaseEventEditStore';
+import { getReasonPhrase } from 'http-status-codes';
 import _ from 'lodash';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
@@ -728,8 +729,8 @@ const EventEditLayout = observer(
 							navigate(EntryUrlMapper.details(EntryType.ReleaseEvent, id));
 						} catch (error: any) {
 							showErrorMessage(
-								error.response && error.response.statusText
-									? error.response.statusText
+								error.response && error.response.status
+									? getReasonPhrase(error.response.status)
 									: 'Unable to save properties.' /* TODO: localize */,
 							);
 

--- a/VocaDbWeb/Scripts/Pages/Event/EventEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Event/EventEdit.tsx
@@ -728,7 +728,9 @@ const EventEditLayout = observer(
 							navigate(EntryUrlMapper.details(EntryType.ReleaseEvent, id));
 						} catch (error: any) {
 							showErrorMessage(
-								'Unable to save properties.' /* TODO: localize */,
+								error.response && error.response.statusText
+									? error.response.statusText
+									: 'Unable to save properties.' /* TODO: localize */,
 							);
 
 							throw e;

--- a/VocaDbWeb/Scripts/Pages/Event/EventEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Event/EventEdit.tsx
@@ -726,7 +726,7 @@ const EventEditLayout = observer(
 							);
 
 							navigate(EntryUrlMapper.details(EntryType.ReleaseEvent, id));
-						} catch (e) {
+						} catch (error: any) {
 							showErrorMessage(
 								'Unable to save properties.' /* TODO: localize */,
 							);

--- a/VocaDbWeb/Scripts/Pages/Event/EventEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Event/EventEdit.tsx
@@ -40,6 +40,7 @@ import { ContentLanguageSelection } from '@/Models/Globalization/ContentLanguage
 import { ImageSize } from '@/Models/Images/ImageSize';
 import { LoginManager } from '@/Models/LoginManager';
 import { SongListFeaturedCategory } from '@/Models/SongLists/SongListFeaturedCategory';
+import { AntiforgeryRepository } from '@/Repositories/AntiforgeryRepository';
 import { ArtistRepository } from '@/Repositories/ArtistRepository';
 import { PVRepository } from '@/Repositories/PVRepository';
 import { ReleaseEventRepository } from '@/Repositories/ReleaseEventRepository';
@@ -66,6 +67,7 @@ const loginManager = new LoginManager(vdb.values);
 const httpClient = new HttpClient();
 const urlMapper = new UrlMapper(vdb.values.baseAddress);
 
+const antiforgeryRepo = new AntiforgeryRepository(httpClient, urlMapper);
 const eventRepo = new ReleaseEventRepository(httpClient, urlMapper);
 const artistRepo = new ArtistRepository(httpClient, vdb.values.baseAddress);
 const pvRepo = new PVRepository(httpClient, urlMapper);
@@ -713,10 +715,15 @@ const EventEditLayout = observer(
 						e.preventDefault();
 
 						try {
+							const requestToken = await antiforgeryRepo.getToken();
+
 							const pictureUpload =
 								pictureUploadRef.current.files?.item(0) ?? undefined;
 
-							const id = await releaseEventEditStore.submit(pictureUpload);
+							const id = await releaseEventEditStore.submit(
+								requestToken,
+								pictureUpload,
+							);
 
 							navigate(EntryUrlMapper.details(EntryType.ReleaseEvent, id));
 						} catch (e) {

--- a/VocaDbWeb/Scripts/Pages/Event/EventEditSeries.tsx
+++ b/VocaDbWeb/Scripts/Pages/Event/EventEditSeries.tsx
@@ -209,7 +209,9 @@ const EventEditSeriesLayout = observer(
 							);
 						} catch (error: any) {
 							showErrorMessage(
-								'Unable to save properties.' /* TODO: localize */,
+								error.response && error.response.statusText
+									? error.response.statusText
+									: 'Unable to save properties.' /* TODO: localize */,
 							);
 
 							throw e;

--- a/VocaDbWeb/Scripts/Pages/Event/EventEditSeries.tsx
+++ b/VocaDbWeb/Scripts/Pages/Event/EventEditSeries.tsx
@@ -29,6 +29,7 @@ import { EventCategory } from '@/Models/Events/EventCategory';
 import { ContentLanguageSelection } from '@/Models/Globalization/ContentLanguageSelection';
 import { ImageSize } from '@/Models/Images/ImageSize';
 import { LoginManager } from '@/Models/LoginManager';
+import { AntiforgeryRepository } from '@/Repositories/AntiforgeryRepository';
 import { ReleaseEventRepository } from '@/Repositories/ReleaseEventRepository';
 import { EntryUrlMapper } from '@/Shared/EntryUrlMapper';
 import { HttpClient } from '@/Shared/HttpClient';
@@ -46,6 +47,7 @@ const loginManager = new LoginManager(vdb.values);
 const httpClient = new HttpClient();
 const urlMapper = new UrlMapper(vdb.values.baseAddress);
 
+const antiforgeryRepo = new AntiforgeryRepository(httpClient, urlMapper);
 const eventRepo = new ReleaseEventRepository(httpClient, urlMapper);
 
 interface EventEditSeriesLayoutProps {
@@ -192,10 +194,13 @@ const EventEditSeriesLayout = observer(
 						e.preventDefault();
 
 						try {
+							const requestToken = await antiforgeryRepo.getToken();
+
 							const pictureUpload =
 								pictureUploadRef.current.files?.item(0) ?? undefined;
 
 							const id = await releaseEventSeriesEditStore.submit(
+								requestToken,
 								pictureUpload,
 							);
 

--- a/VocaDbWeb/Scripts/Pages/Event/EventEditSeries.tsx
+++ b/VocaDbWeb/Scripts/Pages/Event/EventEditSeries.tsx
@@ -35,6 +35,7 @@ import { EntryUrlMapper } from '@/Shared/EntryUrlMapper';
 import { HttpClient } from '@/Shared/HttpClient';
 import { UrlMapper } from '@/Shared/UrlMapper';
 import { ReleaseEventSeriesEditStore } from '@/Stores/ReleaseEvent/ReleaseEventSeriesEditStore';
+import { getReasonPhrase } from 'http-status-codes';
 import _ from 'lodash';
 import { reaction, runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
@@ -209,8 +210,8 @@ const EventEditSeriesLayout = observer(
 							);
 						} catch (error: any) {
 							showErrorMessage(
-								error.response && error.response.statusText
-									? error.response.statusText
+								error.response && error.response.status
+									? getReasonPhrase(error.response.status)
 									: 'Unable to save properties.' /* TODO: localize */,
 							);
 

--- a/VocaDbWeb/Scripts/Pages/Event/EventEditSeries.tsx
+++ b/VocaDbWeb/Scripts/Pages/Event/EventEditSeries.tsx
@@ -207,7 +207,7 @@ const EventEditSeriesLayout = observer(
 							navigate(
 								EntryUrlMapper.details(EntryType.ReleaseEventSeries, id),
 							);
-						} catch (e) {
+						} catch (error: any) {
 							showErrorMessage(
 								'Unable to save properties.' /* TODO: localize */,
 							);

--- a/VocaDbWeb/Scripts/Pages/Song/SongCreate.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongCreate.tsx
@@ -81,7 +81,7 @@ const SongCreateLayout = observer(
 							const id = await songCreateStore.submit(requestToken);
 
 							navigate(`/Song/Edit/${id}`);
-						} catch (e) {
+						} catch (error: any) {
 							showErrorMessage(t('ViewRes.Song:Create.UnableToCreateSong'));
 
 							throw e;

--- a/VocaDbWeb/Scripts/Pages/Song/SongCreate.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongCreate.tsx
@@ -18,11 +18,13 @@ import { showErrorMessage } from '@/Components/ui';
 import { useVocaDbTitle } from '@/Components/useVocaDbTitle';
 import { SongHelper } from '@/Helpers/SongHelper';
 import { SongType } from '@/Models/Songs/SongType';
+import { AntiforgeryRepository } from '@/Repositories/AntiforgeryRepository';
 import { ArtistRepository } from '@/Repositories/ArtistRepository';
 import { SongRepository } from '@/Repositories/SongRepository';
 import { TagRepository } from '@/Repositories/TagRepository';
 import { EntryUrlMapper } from '@/Shared/EntryUrlMapper';
 import { HttpClient } from '@/Shared/HttpClient';
+import { UrlMapper } from '@/Shared/UrlMapper';
 import { SongCreateStore } from '@/Stores/Song/SongCreateStore';
 import _ from 'lodash';
 import { runInAction } from 'mobx';
@@ -32,7 +34,9 @@ import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 
 const httpClient = new HttpClient();
+const urlMapper = new UrlMapper(vdb.values.baseAddress);
 
+const antiforgeryRepo = new AntiforgeryRepository(httpClient, urlMapper);
 const songRepo = new SongRepository(httpClient, vdb.values.baseAddress);
 const artistRepo = new ArtistRepository(httpClient, vdb.values.baseAddress);
 const tagRepo = new TagRepository(httpClient, vdb.values.baseAddress);
@@ -72,7 +76,9 @@ const SongCreateLayout = observer(
 						e.preventDefault();
 
 						try {
-							const id = await songCreateStore.submit();
+							const requestToken = await antiforgeryRepo.getToken();
+
+							const id = await songCreateStore.submit(requestToken);
 
 							navigate(`/Song/Edit/${id}`);
 						} catch (e) {

--- a/VocaDbWeb/Scripts/Pages/Song/SongCreate.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongCreate.tsx
@@ -26,6 +26,7 @@ import { EntryUrlMapper } from '@/Shared/EntryUrlMapper';
 import { HttpClient } from '@/Shared/HttpClient';
 import { UrlMapper } from '@/Shared/UrlMapper';
 import { SongCreateStore } from '@/Stores/Song/SongCreateStore';
+import { getReasonPhrase } from 'http-status-codes';
 import _ from 'lodash';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
@@ -83,8 +84,8 @@ const SongCreateLayout = observer(
 							navigate(`/Song/Edit/${id}`);
 						} catch (error: any) {
 							showErrorMessage(
-								error.response && error.response.statusText
-									? error.response.statusText
+								error.response && error.response.status
+									? getReasonPhrase(error.response.status)
 									: t('ViewRes.Song:Create.UnableToCreateSong'),
 							);
 

--- a/VocaDbWeb/Scripts/Pages/Song/SongCreate.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongCreate.tsx
@@ -82,7 +82,11 @@ const SongCreateLayout = observer(
 
 							navigate(`/Song/Edit/${id}`);
 						} catch (error: any) {
-							showErrorMessage(t('ViewRes.Song:Create.UnableToCreateSong'));
+							showErrorMessage(
+								error.response && error.response.statusText
+									? error.response.statusText
+									: t('ViewRes.Song:Create.UnableToCreateSong'),
+							);
 
 							throw e;
 						}

--- a/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
@@ -821,7 +821,9 @@ const SongEditLayout = observer(
 							navigate(EntryUrlMapper.details(EntryType.Song, id));
 						} catch (error: any) {
 							showErrorMessage(
-								'Unable to save properties.' /* TODO: localize */,
+								error.response && error.response.statusText
+									? error.response.statusText
+									: 'Unable to save properties.' /* TODO: localize */,
 							);
 
 							throw e;

--- a/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
@@ -44,6 +44,7 @@ import SongBpmFilter from '@/Pages/Search/Partials/SongBpmFilter';
 import SongLengthFilter from '@/Pages/Search/Partials/SongLengthFilter';
 import ArtistForSongEdit from '@/Pages/Song/Partials/ArtistForSongEdit';
 import LyricsForSongEdit from '@/Pages/Song/Partials/LyricsForSongEdit';
+import { AntiforgeryRepository } from '@/Repositories/AntiforgeryRepository';
 import { ArtistRepository } from '@/Repositories/ArtistRepository';
 import { PVRepository } from '@/Repositories/PVRepository';
 import { ReleaseEventRepository } from '@/Repositories/ReleaseEventRepository';
@@ -67,6 +68,7 @@ const loginManager = new LoginManager(vdb.values);
 const httpClient = new HttpClient();
 const urlMapper = new UrlMapper(vdb.values.baseAddress);
 
+const antiforgeryRepo = new AntiforgeryRepository(httpClient, urlMapper);
 const songRepo = new SongRepository(httpClient, vdb.values.baseAddress);
 const artistRepo = new ArtistRepository(httpClient, vdb.values.baseAddress);
 const pvRepo = new PVRepository(httpClient, urlMapper);
@@ -812,7 +814,9 @@ const SongEditLayout = observer(
 						e.preventDefault();
 
 						try {
-							const id = await songEditStore.submit();
+							const requestToken = await antiforgeryRepo.getToken();
+
+							const id = await songEditStore.submit(requestToken);
 
 							navigate(EntryUrlMapper.details(EntryType.Song, id));
 						} catch (e) {

--- a/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
@@ -819,7 +819,7 @@ const SongEditLayout = observer(
 							const id = await songEditStore.submit(requestToken);
 
 							navigate(EntryUrlMapper.details(EntryType.Song, id));
-						} catch (e) {
+						} catch (error: any) {
 							showErrorMessage(
 								'Unable to save properties.' /* TODO: localize */,
 							);

--- a/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
@@ -54,6 +54,7 @@ import { HttpClient } from '@/Shared/HttpClient';
 import { UrlMapper } from '@/Shared/UrlMapper';
 import { LyricsForSongListEditStore } from '@/Stores/Song/LyricsForSongListEditStore';
 import { SongEditStore } from '@/Stores/Song/SongEditStore';
+import { getReasonPhrase } from 'http-status-codes';
 import _ from 'lodash';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
@@ -821,8 +822,8 @@ const SongEditLayout = observer(
 							navigate(EntryUrlMapper.details(EntryType.Song, id));
 						} catch (error: any) {
 							showErrorMessage(
-								error.response && error.response.statusText
-									? error.response.statusText
+								error.response && error.response.status
+									? getReasonPhrase(error.response.status)
 									: 'Unable to save properties.' /* TODO: localize */,
 							);
 

--- a/VocaDbWeb/Scripts/Pages/SongList/SongListEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/SongList/SongListEdit.tsx
@@ -391,7 +391,9 @@ const SongListEditLayout = observer(
 							navigate(EntryUrlMapper.details(EntryType.SongList, id));
 						} catch (error: any) {
 							showErrorMessage(
-								'Unable to save properties.' /* TODO: localize */,
+								error.response && error.response.statusText
+									? error.response.statusText
+									: 'Unable to save properties.' /* TODO: localize */,
 							);
 
 							throw e;

--- a/VocaDbWeb/Scripts/Pages/SongList/SongListEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/SongList/SongListEdit.tsx
@@ -29,6 +29,7 @@ import { EntryType } from '@/Models/EntryType';
 import { ImageSize } from '@/Models/Images/ImageSize';
 import { LoginManager } from '@/Models/LoginManager';
 import { SongListFeaturedCategory } from '@/Models/SongLists/SongListFeaturedCategory';
+import { AntiforgeryRepository } from '@/Repositories/AntiforgeryRepository';
 import { SongListRepository } from '@/Repositories/SongListRepository';
 import { SongRepository } from '@/Repositories/SongRepository';
 import { EntryUrlMapper } from '@/Shared/EntryUrlMapper';
@@ -47,6 +48,7 @@ const loginManager = new LoginManager(vdb.values);
 const httpClient = new HttpClient();
 const urlMapper = new UrlMapper(vdb.values.baseAddress);
 
+const antiforgeryRepo = new AntiforgeryRepository(httpClient, urlMapper);
 const songListRepo = new SongListRepository(httpClient, urlMapper);
 const songRepo = new SongRepository(httpClient, vdb.values.baseAddress);
 
@@ -376,10 +378,15 @@ const SongListEditLayout = observer(
 						e.preventDefault();
 
 						try {
+							const requestToken = await antiforgeryRepo.getToken();
+
 							const thumbPicUpload =
 								thumbPicUploadRef.current.files?.item(0) ?? undefined;
 
-							const id = await songListEditStore.submit(thumbPicUpload);
+							const id = await songListEditStore.submit(
+								requestToken,
+								thumbPicUpload,
+							);
 
 							navigate(EntryUrlMapper.details(EntryType.SongList, id));
 						} catch (e) {

--- a/VocaDbWeb/Scripts/Pages/SongList/SongListEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/SongList/SongListEdit.tsx
@@ -36,6 +36,7 @@ import { EntryUrlMapper } from '@/Shared/EntryUrlMapper';
 import { HttpClient } from '@/Shared/HttpClient';
 import { UrlMapper } from '@/Shared/UrlMapper';
 import { SongListEditStore } from '@/Stores/SongList/SongListEditStore';
+import { getReasonPhrase } from 'http-status-codes';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
@@ -391,8 +392,8 @@ const SongListEditLayout = observer(
 							navigate(EntryUrlMapper.details(EntryType.SongList, id));
 						} catch (error: any) {
 							showErrorMessage(
-								error.response && error.response.statusText
-									? error.response.statusText
+								error.response && error.response.status
+									? getReasonPhrase(error.response.status)
 									: 'Unable to save properties.' /* TODO: localize */,
 							);
 

--- a/VocaDbWeb/Scripts/Pages/SongList/SongListEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/SongList/SongListEdit.tsx
@@ -389,7 +389,7 @@ const SongListEditLayout = observer(
 							);
 
 							navigate(EntryUrlMapper.details(EntryType.SongList, id));
-						} catch (e) {
+						} catch (error: any) {
 							showErrorMessage(
 								'Unable to save properties.' /* TODO: localize */,
 							);

--- a/VocaDbWeb/Scripts/Pages/Tag/TagEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Tag/TagEdit.tsx
@@ -37,6 +37,7 @@ import { EntryUrlMapper } from '@/Shared/EntryUrlMapper';
 import { HttpClient } from '@/Shared/HttpClient';
 import { UrlMapper } from '@/Shared/UrlMapper';
 import { TagEditStore } from '@/Stores/Tag/TagEditStore';
+import { getReasonPhrase } from 'http-status-codes';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
@@ -201,8 +202,8 @@ const TagEditLayout = observer(
 							navigate(EntryUrlMapper.details_tag(id));
 						} catch (error: any) {
 							showErrorMessage(
-								error.response && error.response.statusText
-									? error.response.statusText
+								error.response && error.response.status
+									? getReasonPhrase(error.response.status)
 									: 'Unable to save properties.' /* TODO: localize */,
 							);
 

--- a/VocaDbWeb/Scripts/Pages/Tag/TagEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Tag/TagEdit.tsx
@@ -201,7 +201,9 @@ const TagEditLayout = observer(
 							navigate(EntryUrlMapper.details_tag(id));
 						} catch (error: any) {
 							showErrorMessage(
-								'Unable to save properties.' /* TODO: localize */,
+								error.response && error.response.statusText
+									? error.response.statusText
+									: 'Unable to save properties.' /* TODO: localize */,
 							);
 
 							throw e;

--- a/VocaDbWeb/Scripts/Pages/Tag/TagEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Tag/TagEdit.tsx
@@ -31,6 +31,7 @@ import { EntryType } from '@/Models/EntryType';
 import { ImageSize } from '@/Models/Images/ImageSize';
 import { LoginManager } from '@/Models/LoginManager';
 import { TagTargetTypes } from '@/Models/Tags/TagTargetTypes';
+import { AntiforgeryRepository } from '@/Repositories/AntiforgeryRepository';
 import { TagRepository } from '@/Repositories/TagRepository';
 import { EntryUrlMapper } from '@/Shared/EntryUrlMapper';
 import { HttpClient } from '@/Shared/HttpClient';
@@ -47,6 +48,7 @@ const loginManager = new LoginManager(vdb.values);
 const httpClient = new HttpClient();
 const urlMapper = new UrlMapper(vdb.values.baseAddress);
 
+const antiforgeryRepo = new AntiforgeryRepository(httpClient, urlMapper);
 const tagRepo = new TagRepository(httpClient, vdb.values.baseAddress);
 
 const allTagTargetTypes: TagTargetTypes[] = [
@@ -185,10 +187,13 @@ const TagEditLayout = observer(
 						e.preventDefault();
 
 						try {
+							const requestToken = await antiforgeryRepo.getToken();
+
 							const thumbPicUpload =
 								thumbPicUploadRef.current.files?.item(0) ?? undefined;
 
 							const id = await tagEditStore.submit(
+								requestToken,
 								categoryNameRef.current.value,
 								thumbPicUpload,
 							);

--- a/VocaDbWeb/Scripts/Pages/Tag/TagEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Tag/TagEdit.tsx
@@ -199,7 +199,7 @@ const TagEditLayout = observer(
 							);
 
 							navigate(EntryUrlMapper.details_tag(id));
-						} catch (e) {
+						} catch (error: any) {
 							showErrorMessage(
 								'Unable to save properties.' /* TODO: localize */,
 							);

--- a/VocaDbWeb/Scripts/Pages/Venue/VenueEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Venue/VenueEdit.tsx
@@ -25,6 +25,7 @@ import { EntryStatus } from '@/Models/EntryStatus';
 import { EntryType } from '@/Models/EntryType';
 import { ContentLanguageSelection } from '@/Models/Globalization/ContentLanguageSelection';
 import { LoginManager } from '@/Models/LoginManager';
+import { AntiforgeryRepository } from '@/Repositories/AntiforgeryRepository';
 import { VenueRepository } from '@/Repositories/VenueRepository';
 import { EntryUrlMapper } from '@/Shared/EntryUrlMapper';
 import { HttpClient } from '@/Shared/HttpClient';
@@ -42,6 +43,7 @@ const loginManager = new LoginManager(vdb.values);
 const httpClient = new HttpClient();
 const urlMapper = new UrlMapper(vdb.values.baseAddress);
 
+const antiforgeryRepo = new AntiforgeryRepository(httpClient, urlMapper);
 const venueRepo = new VenueRepository(httpClient, urlMapper);
 
 interface VenueEditLayoutProps {
@@ -161,7 +163,9 @@ const VenueEditLayout = observer(
 						e.preventDefault();
 
 						try {
-							const id = await venueEditStore.submit();
+							const requestToken = await antiforgeryRepo.getToken();
+
+							const id = await venueEditStore.submit(requestToken);
 
 							navigate(EntryUrlMapper.details(EntryType.Venue, id));
 						} catch {

--- a/VocaDbWeb/Scripts/Pages/Venue/VenueEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Venue/VenueEdit.tsx
@@ -170,7 +170,9 @@ const VenueEditLayout = observer(
 							navigate(EntryUrlMapper.details(EntryType.Venue, id));
 						} catch (error: any) {
 							showErrorMessage(
-								'Unable to save properties.' /* TODO: localize */,
+								error.response && error.response.statusText
+									? error.response.statusText
+									: 'Unable to save properties.' /* TODO: localize */,
 							);
 						}
 					}}

--- a/VocaDbWeb/Scripts/Pages/Venue/VenueEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Venue/VenueEdit.tsx
@@ -31,6 +31,7 @@ import { EntryUrlMapper } from '@/Shared/EntryUrlMapper';
 import { HttpClient } from '@/Shared/HttpClient';
 import { UrlMapper } from '@/Shared/UrlMapper';
 import { VenueEditStore } from '@/Stores/Venue/VenueEditStore';
+import { getReasonPhrase } from 'http-status-codes';
 import _ from 'lodash';
 import { reaction, runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
@@ -170,8 +171,8 @@ const VenueEditLayout = observer(
 							navigate(EntryUrlMapper.details(EntryType.Venue, id));
 						} catch (error: any) {
 							showErrorMessage(
-								error.response && error.response.statusText
-									? error.response.statusText
+								error.response && error.response.status
+									? getReasonPhrase(error.response.status)
 									: 'Unable to save properties.' /* TODO: localize */,
 							);
 						}

--- a/VocaDbWeb/Scripts/Pages/Venue/VenueEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Venue/VenueEdit.tsx
@@ -168,7 +168,7 @@ const VenueEditLayout = observer(
 							const id = await venueEditStore.submit(requestToken);
 
 							navigate(EntryUrlMapper.details(EntryType.Venue, id));
-						} catch {
+						} catch (error: any) {
 							showErrorMessage(
 								'Unable to save properties.' /* TODO: localize */,
 							);

--- a/VocaDbWeb/Scripts/Repositories/AlbumRepository.ts
+++ b/VocaDbWeb/Scripts/Repositories/AlbumRepository.ts
@@ -333,7 +333,10 @@ export class AlbumRepository
 		>(this.urlMapper.mapRelative(`/api/albums/${id}/versions`));
 	};
 
-	public create = (contract: CreateAlbumContract): Promise<number> => {
+	public create = (
+		requestToken: string,
+		contract: CreateAlbumContract,
+	): Promise<number> => {
 		const formData = new FormData();
 		formData.append('contract', JSON.stringify(contract));
 
@@ -343,13 +346,14 @@ export class AlbumRepository
 			{
 				headers: {
 					'Content-Type': 'multipart/form-data',
-					requestVerificationToken: vdb.values.requestToken,
+					requestVerificationToken: requestToken,
 				},
 			},
 		);
 	};
 
 	public edit = (
+		requestToken: string,
 		contract: AlbumForEditContract,
 		coverPicUpload: File | undefined,
 		pictureUpload: File[],
@@ -367,7 +371,7 @@ export class AlbumRepository
 			{
 				headers: {
 					'Content-Type': 'multipart/form-data',
-					requestVerificationToken: vdb.values.requestToken,
+					requestVerificationToken: requestToken,
 				},
 			},
 		);

--- a/VocaDbWeb/Scripts/Repositories/AntiforgeryRepository.ts
+++ b/VocaDbWeb/Scripts/Repositories/AntiforgeryRepository.ts
@@ -1,0 +1,24 @@
+import { HttpClient } from '@/Shared/HttpClient';
+import { UrlMapper } from '@/Shared/UrlMapper';
+
+export class AntiforgeryRepository {
+	public constructor(
+		private readonly httpClient: HttpClient,
+		private readonly urlMapper: UrlMapper,
+	) {}
+
+	public getToken = async (): Promise<string> => {
+		await this.httpClient.get<void>(
+			this.urlMapper.mapRelative('/api/antiforgery/token'),
+		);
+
+		// Code from: https://docs.microsoft.com/en-us/aspnet/core/security/anti-request-forgery?view=aspnetcore-6.0#javascript-1.
+		// https://developer.mozilla.org/docs/web/api/document/cookie
+		const xsrfToken = document.cookie
+			.split('; ')
+			.find((row) => row.startsWith('XSRF-TOKEN='))!
+			.split('=')[1];
+
+		return xsrfToken;
+	};
+}

--- a/VocaDbWeb/Scripts/Repositories/ArtistRepository.ts
+++ b/VocaDbWeb/Scripts/Repositories/ArtistRepository.ts
@@ -259,6 +259,7 @@ export class ArtistRepository
 	};
 
 	public create = (
+		requestToken: string,
 		contract: CreateArtistContract,
 		pictureUpload: File | undefined,
 	): Promise<number> => {
@@ -273,13 +274,14 @@ export class ArtistRepository
 			{
 				headers: {
 					'Content-Type': 'multipart/form-data',
-					requestVerificationToken: vdb.values.requestToken,
+					requestVerificationToken: requestToken,
 				},
 			},
 		);
 	};
 
 	public edit = (
+		requestToken: string,
 		contract: ArtistForEditContract,
 		coverPicUpload: File | undefined,
 		pictureUpload: File[],
@@ -297,7 +299,7 @@ export class ArtistRepository
 			{
 				headers: {
 					'Content-Type': 'multipart/form-data',
-					requestVerificationToken: vdb.values.requestToken,
+					requestVerificationToken: requestToken,
 				},
 			},
 		);

--- a/VocaDbWeb/Scripts/Repositories/ReleaseEventRepository.ts
+++ b/VocaDbWeb/Scripts/Repositories/ReleaseEventRepository.ts
@@ -226,6 +226,7 @@ export class ReleaseEventRepository extends BaseRepository {
 	};
 
 	public edit = (
+		requestToken: string,
 		contract: ReleaseEventForEditContract,
 		pictureUpload: File | undefined,
 	): Promise<number> => {
@@ -240,7 +241,7 @@ export class ReleaseEventRepository extends BaseRepository {
 			{
 				headers: {
 					'Content-Type': 'multipart/form-data',
-					requestVerificationToken: vdb.values.requestToken,
+					requestVerificationToken: requestToken,
 				},
 			},
 		);
@@ -257,6 +258,7 @@ export class ReleaseEventRepository extends BaseRepository {
 	};
 
 	public editSeries = (
+		requestToken: string,
 		contract: ReleaseEventSeriesForEditContract,
 		pictureUpload: File | undefined,
 	): Promise<number> => {
@@ -271,7 +273,7 @@ export class ReleaseEventRepository extends BaseRepository {
 			{
 				headers: {
 					'Content-Type': 'multipart/form-data',
-					requestVerificationToken: vdb.values.requestToken,
+					requestVerificationToken: requestToken,
 				},
 			},
 		);

--- a/VocaDbWeb/Scripts/Repositories/SongListRepository.ts
+++ b/VocaDbWeb/Scripts/Repositories/SongListRepository.ts
@@ -158,6 +158,7 @@ export class SongListRepository {
 	};
 
 	public edit = (
+		requestToken: string,
 		contract: SongListForEditContract,
 		thumbPicUpload: File | undefined,
 	): Promise<number> => {
@@ -172,7 +173,7 @@ export class SongListRepository {
 			{
 				headers: {
 					'Content-Type': 'multipart/form-data',
-					requestVerificationToken: vdb.values.requestToken,
+					requestVerificationToken: requestToken,
 				},
 			},
 		);

--- a/VocaDbWeb/Scripts/Repositories/SongRepository.ts
+++ b/VocaDbWeb/Scripts/Repositories/SongRepository.ts
@@ -550,7 +550,10 @@ export class SongRepository
 		>(this.urlMapper.mapRelative(`/api/songs/${id}/versions`));
 	};
 
-	public create = (contract: CreateSongContract): Promise<number> => {
+	public create = (
+		requestToken: string,
+		contract: CreateSongContract,
+	): Promise<number> => {
 		const formData = new FormData();
 		formData.append('contract', JSON.stringify(contract));
 
@@ -560,13 +563,16 @@ export class SongRepository
 			{
 				headers: {
 					'Content-Type': 'multipart/form-data',
-					requestVerificationToken: vdb.values.requestToken,
+					requestVerificationToken: requestToken,
 				},
 			},
 		);
 	};
 
-	public edit = (contract: SongForEditContract): Promise<number> => {
+	public edit = (
+		requestToken: string,
+		contract: SongForEditContract,
+	): Promise<number> => {
 		const formData = new FormData();
 		formData.append('contract', JSON.stringify(contract));
 
@@ -576,7 +582,7 @@ export class SongRepository
 			{
 				headers: {
 					'Content-Type': 'multipart/form-data',
-					requestVerificationToken: vdb.values.requestToken,
+					requestVerificationToken: requestToken,
 				},
 			},
 		);

--- a/VocaDbWeb/Scripts/Repositories/TagRepository.ts
+++ b/VocaDbWeb/Scripts/Repositories/TagRepository.ts
@@ -210,6 +210,7 @@ export class TagRepository extends BaseRepository {
 	};
 
 	public edit = (
+		requestToken: string,
 		contract: TagForEditContract,
 		thumbPicUpload: File | undefined,
 	): Promise<number> => {
@@ -224,7 +225,7 @@ export class TagRepository extends BaseRepository {
 			{
 				headers: {
 					'Content-Type': 'multipart/form-data',
-					requestVerificationToken: vdb.values.requestToken,
+					requestVerificationToken: requestToken,
 				},
 			},
 		);

--- a/VocaDbWeb/Scripts/Repositories/VenueRepository.ts
+++ b/VocaDbWeb/Scripts/Repositories/VenueRepository.ts
@@ -115,11 +115,14 @@ export class VenueRepository extends BaseRepository {
 		);
 	};
 
-	public edit = (contract: VenueForEditContract): Promise<number> => {
+	public edit = (
+		requestToken: string,
+		contract: VenueForEditContract,
+	): Promise<number> => {
 		return this.httpClient.post<number>(
 			this.urlMapper.mapRelative(`/api/venues/${contract.id}`),
 			contract,
-			{ headers: { requestVerificationToken: vdb.values.requestToken } },
+			{ headers: { requestVerificationToken: requestToken } },
 		);
 	};
 }

--- a/VocaDbWeb/Scripts/Shared/GlobalValues.ts
+++ b/VocaDbWeb/Scripts/Shared/GlobalValues.ts
@@ -54,6 +54,4 @@ export interface GlobalValues {
 	bigBanners: MenuPageLink[];
 	smallBanners: MenuPageLink[];
 	socialLinks: MenuPageLink[];
-
-	requestToken?: string;
 }

--- a/VocaDbWeb/Scripts/Stores/Album/AlbumCreateStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Album/AlbumCreateStore.ts
@@ -60,11 +60,11 @@ export class AlbumCreateStore {
 		_.pull(this.artists, artist);
 	};
 
-	@action public submit = async (): Promise<number> => {
+	@action public submit = async (requestToken: string): Promise<number> => {
 		this.submitting = true;
 
 		try {
-			const id = await this.albumRepo.create({
+			const id = await this.albumRepo.create(requestToken, {
 				artists: this.artists,
 				discType: this.discType,
 				names: ([] as LocalizedStringContract[]).concat(

--- a/VocaDbWeb/Scripts/Stores/Album/AlbumEditStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Album/AlbumEditStore.ts
@@ -489,6 +489,7 @@ export class AlbumEditStore {
 	};
 
 	@action public submit = async (
+		requestToken: string,
 		coverPicUpload: File | undefined,
 		pictureUpload: File[],
 	): Promise<number> => {
@@ -496,6 +497,7 @@ export class AlbumEditStore {
 
 		try {
 			const id = await this.albumRepo.edit(
+				requestToken,
 				{
 					artistLinks: this.artistLinks.map((artist) => artist.toContract()),
 					defaultNameLanguage: this.defaultNameLanguage,

--- a/VocaDbWeb/Scripts/Stores/Artist/ArtistCreateStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Artist/ArtistCreateStore.ts
@@ -86,12 +86,14 @@ export class ArtistCreateStore {
 	};
 
 	@action public submit = async (
+		requestToken: string,
 		pictureUpload: File | undefined,
 	): Promise<number> => {
 		this.submitting = true;
 
 		try {
 			const id = await this.artistRepo.create(
+				requestToken,
 				{
 					artistType: this.artistType,
 					description: this.description,

--- a/VocaDbWeb/Scripts/Stores/Artist/ArtistEditStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Artist/ArtistEditStore.ts
@@ -230,6 +230,7 @@ export class ArtistEditStore {
 	};
 
 	@action public submit = async (
+		requestToken: string,
 		coverPicUpload: File | undefined,
 		pictureUpload: File[],
 	): Promise<number> => {
@@ -237,6 +238,7 @@ export class ArtistEditStore {
 
 		try {
 			const id = await this.artistRepo.edit(
+				requestToken,
 				{
 					artistType: this.artistType,
 					associatedArtists: this.associatedArtists.map((a) => a.toContract()),

--- a/VocaDbWeb/Scripts/Stores/ReleaseEvent/ReleaseEventEditStore.ts
+++ b/VocaDbWeb/Scripts/Stores/ReleaseEvent/ReleaseEventEditStore.ts
@@ -195,12 +195,14 @@ export class ReleaseEventEditStore {
 	};
 
 	@action public submit = async (
+		requestToken: string,
 		pictureUpload: File | undefined,
 	): Promise<number> => {
 		this.submitting = true;
 
 		try {
 			const id = await this.eventRepo.edit(
+				requestToken,
 				{
 					artists: this.artistLinkContracts,
 					category: this.category,

--- a/VocaDbWeb/Scripts/Stores/ReleaseEvent/ReleaseEventSeriesEditStore.ts
+++ b/VocaDbWeb/Scripts/Stores/ReleaseEvent/ReleaseEventSeriesEditStore.ts
@@ -63,12 +63,14 @@ export class ReleaseEventSeriesEditStore {
 	};
 
 	@action public submit = async (
+		requestToken: string,
 		pictureUpload: File | undefined,
 	): Promise<number> => {
 		this.submitting = true;
 
 		try {
 			const id = await this.eventRepo.editSeries(
+				requestToken,
 				{
 					category: this.category,
 					defaultNameLanguage: this.defaultNameLanguage,

--- a/VocaDbWeb/Scripts/Stores/Song/SongCreateStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Song/SongCreateStore.ts
@@ -213,11 +213,11 @@ export class SongCreateStore {
 		});
 	};
 
-	@action public submit = async (): Promise<number> => {
+	@action public submit = async (requestToken: string): Promise<number> => {
 		this.submitting = true;
 
 		try {
-			const id = await this.songRepo.create({
+			const id = await this.songRepo.create(requestToken, {
 				artists: this.artists.map(
 					(artist) =>
 						({

--- a/VocaDbWeb/Scripts/Stores/Song/SongEditStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Song/SongEditStore.ts
@@ -388,11 +388,11 @@ export class SongEditStore {
 		this.originalVersion.id = song.id;
 	};
 
-	@action public submit = async (): Promise<number> => {
+	@action public submit = async (requestToken: string): Promise<number> => {
 		this.submitting = true;
 
 		try {
-			const id = await this.songRepo.edit({
+			const id = await this.songRepo.edit(requestToken, {
 				artists: this.artistLinks.map((artistLink) => artistLink.toContract()),
 				defaultNameLanguage: this.defaultNameLanguage,
 				deleted: false,

--- a/VocaDbWeb/Scripts/Stores/SongList/SongListEditStore.ts
+++ b/VocaDbWeb/Scripts/Stores/SongList/SongListEditStore.ts
@@ -122,12 +122,14 @@ export class SongListEditStore {
 	};
 
 	@action public submit = async (
+		requestToken: string,
 		thumbPicUpload: File | undefined,
 	): Promise<number> => {
 		this.submitting = true;
 
 		try {
 			const id = await this.songListRepo.edit(
+				requestToken,
 				{
 					author: undefined!,
 					description: this.description,

--- a/VocaDbWeb/Scripts/Stores/Tag/TagEditStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Tag/TagEditStore.ts
@@ -122,6 +122,7 @@ export class TagEditStore {
 	};
 
 	@action public submit = async (
+		requestToken: string,
 		categoryName: string /* HACK */,
 		thumbPicUpload: File | undefined,
 	): Promise<number> => {
@@ -129,6 +130,7 @@ export class TagEditStore {
 
 		try {
 			const id = await this.tagRepo.edit(
+				requestToken,
 				{
 					canDelete: false,
 					categoryName: categoryName,

--- a/VocaDbWeb/Scripts/Stores/Venue/VenueEditStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Venue/VenueEditStore.ts
@@ -89,11 +89,11 @@ export class VenueEditStore {
 		});
 	};
 
-	@action public submit = async (): Promise<number> => {
+	@action public submit = async (requestToken: string): Promise<number> => {
 		this.submitting = true;
 
 		try {
-			const id = await this.venueRepo.edit({
+			const id = await this.venueRepo.edit(requestToken, {
 				address: this.address,
 				addressCountryCode: this.addressCountryCode,
 				coordinates: this.coordinates,

--- a/VocaDbWeb/Startup.cs
+++ b/VocaDbWeb/Startup.cs
@@ -3,7 +3,6 @@ using System.Security.Claims;
 using AspNetCore.CacheOutput.Extensions;
 using AspNetCore.CacheOutput.InMemory.Extensions;
 using Autofac;
-using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Twitter;
 using Microsoft.AspNetCore.Mvc.Formatters;
@@ -281,21 +280,6 @@ namespace VocaDb.Web
 			// Before UseEndpoints, so that users are authenticated before accessing the endpoints.
 			app.UseAuthentication();
 			app.UseAuthorization();
-
-			// Code from: https://docs.microsoft.com/en-us/aspnet/core/security/anti-request-forgery?view=aspnetcore-6.0#generate-antiforgery-tokens-with-iantiforgery.
-			var antiforgery = app.ApplicationServices.GetRequiredService<IAntiforgery>();
-			app.Use((context, next) =>
-			{
-				var requestPath = context.Request.Path.Value;
-
-				if (string.Equals(requestPath, "/", StringComparison.OrdinalIgnoreCase) || string.Equals(requestPath, "/index.html", StringComparison.OrdinalIgnoreCase))
-				{
-					var tokenSet = antiforgery.GetAndStoreTokens(context);
-					context.Response.Cookies.Append("XSRF-TOKEN", tokenSet.RequestToken!, new CookieOptions { HttpOnly = false });
-				}
-
-				return next(context);
-			});
 
 			app.UseVocaDbPrincipal();
 

--- a/VocaDbWeb/Views/Shared/React/Index.cshtml
+++ b/VocaDbWeb/Views/Shared/React/Index.cshtml
@@ -55,10 +55,7 @@
 		window.vdb = @ToJS(new
 		{
 			Resources = new GlobalResources(this),
-			Values = new GlobalValues(this)
-			{
-				RequestToken = Antiforgery.GetAndStoreTokens(Context).RequestToken,
-			},
+			Values = new GlobalValues(this),
 		});
 	</script>
 	<remikus path="/bundles/manifest.js" />

--- a/VocaDbWeb/package-lock.json
+++ b/VocaDbWeb/package-lock.json
@@ -17,6 +17,7 @@
                 "decimal.js-light": "^2.5.1",
                 "highcharts": "^10.0.0",
                 "highcharts-react-official": "^3.1.0",
+                "http-status-codes": "^2.2.0",
                 "i18next": "^20.3.2",
                 "i18next-http-backend": "^1.2.6",
                 "jquery": "^2.2.1",
@@ -9256,6 +9257,11 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/http-status-codes": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+            "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
         },
         "node_modules/https-browserify": {
             "version": "1.0.0",
@@ -26774,6 +26780,11 @@
                 "is-plain-obj": "^3.0.0",
                 "micromatch": "^4.0.2"
             }
+        },
+        "http-status-codes": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+            "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
         },
         "https-browserify": {
             "version": "1.0.0",

--- a/VocaDbWeb/package.json
+++ b/VocaDbWeb/package.json
@@ -65,6 +65,7 @@
         "decimal.js-light": "^2.5.1",
         "highcharts": "^10.0.0",
         "highcharts-react-official": "^3.1.0",
+        "http-status-codes": "^2.2.0",
         "i18next": "^20.3.2",
         "i18next-http-backend": "^1.2.6",
         "jquery": "^2.2.1",


### PR DESCRIPTION
Fixes #1178.

This PR adds an endpoint (`/api/antiforgery/token`) that sets a cookie with `httpOnly` set to `false` holding the CSRF token.

References:
- [Prevent Cross-Site Request Forgery (XSRF/CSRF) attacks in ASP.NET Core | Microsoft Docs](https://docs.microsoft.com/en-us/aspnet/core/security/anti-request-forgery?view=aspnetcore-6.0#javascript-1)
- [c# - Using ASP.NET Core 6 Web API Antiforgery Token in extern consumer (App) without Authentication - Stack Overflow](https://stackoverflow.com/questions/70559557/using-asp-net-core-6-web-api-antiforgery-token-in-extern-consumer-app-without/70560555#70560555)
- [CSRF tokens for SPAs - Michael Zanggl](https://michaelzanggl.com/articles/csrf-tokens-for-spas/)