### PR TITLE
Parse the URL when creating an external link

### DIFF
--- a/VocaDb.Migrations/Migrations.cs
+++ b/VocaDb.Migrations/Migrations.cs
@@ -32,6 +32,15 @@ public class WebAddress : AutoReversingMigration
 			.WithColumn("Fragment").AsString().NotNullable()
 			.WithColumn("ReferenceCount").AsInt32().NotNullable()
 			.WithColumn("Actor").AsInt32().NotNullable().ForeignKey(TableNames.Users, "Id").Indexed();
+
+		Create.Column("Address").OnTable(TableNames.AlbumWebLinks).AsInt32().Nullable()/* TODO: NotNullable */.Indexed();
+		Create.Column("Address").OnTable(TableNames.ArtistWebLinks).AsInt32().Nullable()/* TODO: NotNullable */.Indexed();
+		Create.Column("Address").OnTable(TableNames.ReleaseEventSeriesWebLinks).AsInt32().Nullable()/* TODO: NotNullable */.Indexed();
+		Create.Column("Address").OnTable(TableNames.ReleaseEventWebLinks).AsInt32().Nullable()/* TODO: NotNullable */.Indexed();
+		Create.Column("Address").OnTable(TableNames.SongWebLinks).AsInt32().Nullable()/* TODO: NotNullable */.Indexed();
+		Create.Column("Address").OnTable(TableNames.TagWebLinks).AsInt32().Nullable()/* TODO: NotNullable */.Indexed();
+		Create.Column("Address").OnTable(TableNames.UserWebLinks).AsInt32().Nullable()/* TODO: NotNullable */.Indexed();
+		Create.Column("Address").OnTable(TableNames.VenueWebLinks).AsInt32().Nullable()/* TODO: NotNullable */.Indexed();
 	}
 }
 

--- a/VocaDb.Migrations/Migrations.cs
+++ b/VocaDb.Migrations/Migrations.cs
@@ -6,6 +6,35 @@ namespace VocaDb.Migrations;
 
 // Migration version format: YYYY_MM_DD_HHmm
 
+[Migration(2022_11_06_0400)]
+public class WebAddress : AutoReversingMigration
+{
+	public override void Up()
+	{
+		Create.Table(TableNames.WebAddressHosts)
+			.WithColumn("Id").AsInt32().NotNullable().Identity().PrimaryKey()
+			.WithColumn("CreatedAt").AsDateTimeOffset().NotNullable()
+			.WithColumn("UpdatedAt").AsDateTimeOffset().NotNullable()
+			.WithColumn("Hostname").AsString().NotNullable().Unique()
+			.WithColumn("ReferenceCount").AsInt32().NotNullable()
+			.WithColumn("Actor").AsInt32().NotNullable().ForeignKey(TableNames.Users, "Id").Indexed();
+
+		Create.Table(TableNames.WebAddresses)
+			.WithColumn("Id").AsInt32().NotNullable().Identity().PrimaryKey()
+			.WithColumn("CreatedAt").AsDateTimeOffset().NotNullable()
+			.WithColumn("UpdatedAt").AsDateTimeOffset().NotNullable()
+			.WithColumn("Url").AsString().NotNullable().Unique()
+			.WithColumn("Scheme").AsString().NotNullable()
+			.WithColumn("Host").AsInt32().NotNullable().ForeignKey(TableNames.WebAddressHosts, "Id").Indexed()
+			.WithColumn("Port").AsInt32().NotNullable()
+			.WithColumn("Path").AsString().NotNullable()
+			.WithColumn("Query").AsString().NotNullable()
+			.WithColumn("Fragment").AsString().NotNullable()
+			.WithColumn("ReferenceCount").AsInt32().NotNullable()
+			.WithColumn("Actor").AsInt32().NotNullable().ForeignKey(TableNames.Users, "Id").Indexed();
+	}
+}
+
 [Migration(2022_03_19_0300)]
 public class UserPicture : AutoReversingMigration
 {

--- a/VocaDb.Migrations/Migrations.cs
+++ b/VocaDb.Migrations/Migrations.cs
@@ -23,13 +23,13 @@ public class WebAddress : AutoReversingMigration
 			.WithColumn("Id").AsInt32().NotNullable().Identity().PrimaryKey()
 			.WithColumn("CreatedAt").AsDateTimeOffset().NotNullable()
 			.WithColumn("UpdatedAt").AsDateTimeOffset().NotNullable()
-			.WithColumn("Url").AsString().NotNullable().Unique()
+			.WithColumn("Url").AsString(512).NotNullable().Unique()
 			.WithColumn("Scheme").AsString().NotNullable()
 			.WithColumn("Host").AsInt32().NotNullable().ForeignKey(TableNames.WebAddressHosts, "Id").Indexed()
 			.WithColumn("Port").AsInt32().NotNullable()
-			.WithColumn("Path").AsString().NotNullable()
-			.WithColumn("Query").AsString().NotNullable()
-			.WithColumn("Fragment").AsString().NotNullable()
+			.WithColumn("Path").AsString(512).NotNullable()
+			.WithColumn("Query").AsString(512).NotNullable()
+			.WithColumn("Fragment").AsString(512).NotNullable()
 			.WithColumn("ReferenceCount").AsInt32().NotNullable()
 			.WithColumn("Actor").AsInt32().NotNullable().ForeignKey(TableNames.Users, "Id").Indexed();
 

--- a/VocaDb.Migrations/Migrations.cs
+++ b/VocaDb.Migrations/Migrations.cs
@@ -13,16 +13,12 @@ public class WebAddress : AutoReversingMigration
 	{
 		Create.Table(TableNames.WebAddressHosts)
 			.WithColumn("Id").AsInt32().NotNullable().Identity().PrimaryKey()
-			.WithColumn("CreatedAt").AsDateTimeOffset().NotNullable()
-			.WithColumn("UpdatedAt").AsDateTimeOffset().NotNullable()
 			.WithColumn("Hostname").AsString().NotNullable().Unique()
 			.WithColumn("ReferenceCount").AsInt32().NotNullable()
 			.WithColumn("Actor").AsInt32().NotNullable().ForeignKey(TableNames.Users, "Id").Indexed();
 
 		Create.Table(TableNames.WebAddresses)
 			.WithColumn("Id").AsInt32().NotNullable().Identity().PrimaryKey()
-			.WithColumn("CreatedAt").AsDateTimeOffset().NotNullable()
-			.WithColumn("UpdatedAt").AsDateTimeOffset().NotNullable()
 			.WithColumn("Url").AsString(512).NotNullable().Unique()
 			.WithColumn("Scheme").AsString().NotNullable()
 			.WithColumn("Host").AsInt32().NotNullable().ForeignKey(TableNames.WebAddressHosts, "Id").Indexed()

--- a/VocaDb.Migrations/TableNames.cs
+++ b/VocaDb.Migrations/TableNames.cs
@@ -75,6 +75,8 @@ namespace VocaDb.Migrations
 		public const string UserWebLinks = nameof(UserWebLinks);
 		public const string Venues = nameof(Venues);
 		public const string VenueWebLinks = nameof(VenueWebLinks);
+		public const string WebAddresses = nameof(WebAddresses);
+		public const string WebAddressHosts = nameof(WebAddressHosts);
 		public const string Webhooks = nameof(Webhooks);
 	}
 

--- a/VocaDbModel/Domain/ExtLinks/WebLink.cs
+++ b/VocaDbModel/Domain/ExtLinks/WebLink.cs
@@ -121,6 +121,9 @@ public class WebLink : IWebLink, IEntryWithIntId
 
 	public virtual int Id { get; set; }
 
+	// TODO: Make non-nullable.
+	public virtual WebAddress? Address { get; set; }
+
 	/// <summary>
 	/// Link URL. Cannot be null or empty.
 	/// </summary>

--- a/VocaDbModel/Domain/WebAddress.cs
+++ b/VocaDbModel/Domain/WebAddress.cs
@@ -1,0 +1,91 @@
+using VocaDb.Model.Domain.Users;
+
+namespace VocaDb.Model.Domain;
+
+// https://github.com/ycanardeau/yamatouta/blob/ba67503d3ded79c942c7240394faa1931e36f0e4/backend/src/entities/WebAddressHost.ts
+public class WebAddressHost
+{
+	public virtual int Id { get; set; }
+
+	public virtual DateTimeOffset CreatedAt { get; set; }
+
+	public virtual DateTimeOffset UpdatedAt { get; set; }
+
+	public virtual required string Hostname { get; set; }
+
+	public virtual int ReferenceCount { get; set; }
+
+	public virtual required User Actor { get; set; }
+
+	public WebAddressHost() { }
+
+	public WebAddressHost(string hostname, User actor)
+	{
+		Hostname = hostname;
+		Actor = actor;
+	}
+
+	public void IncrementReferenceCount()
+	{
+		ReferenceCount++;
+	}
+
+	public void DecrementReferenceCount()
+	{
+		ReferenceCount--;
+	}
+}
+
+// https://github.com/ycanardeau/yamatouta/blob/ba67503d3ded79c942c7240394faa1931e36f0e4/backend/src/entities/WebAddress.ts
+public class WebAddress
+{
+	public virtual int Id { get; set; }
+
+	public virtual DateTimeOffset CreatedAt { get; set; }
+
+	public virtual DateTimeOffset UpdatedAt { get; set; }
+
+	public virtual required string Url { get; set; }
+
+	public virtual required string Scheme { get; set; }
+
+	public virtual required WebAddressHost Host { get; set; }
+
+	public virtual required int Port { get; set; }
+
+	public virtual required string Path { get; set; }
+
+	public virtual required string Query { get; set; }
+
+	public virtual required string Fragment { get; set; }
+
+	public virtual int ReferenceCount { get; set; }
+
+	public virtual required User Actor { get; set; }
+
+	public WebAddress() { }
+
+	public WebAddress(Uri uri, WebAddressHost host, User actor)
+	{
+		Url = uri.ToString();
+		Scheme = uri.Scheme;
+		Host = host;
+		Port = uri.Port;
+		Path = uri.LocalPath;
+		Query = uri.Query;
+		Fragment = uri.Fragment;
+		Actor = actor;
+	}
+
+	public void IncrementReferenceCount()
+	{
+		Host.IncrementReferenceCount();
+		ReferenceCount++;
+	}
+
+	public void DecrementReferenceCount()
+	{
+		Host.DecrementReferenceCount();
+		ReferenceCount--;
+	}
+}

--- a/VocaDbModel/Domain/WebAddress.cs
+++ b/VocaDbModel/Domain/WebAddress.cs
@@ -7,13 +7,17 @@ public class WebAddressHost
 {
 	public virtual int Id { get; set; }
 
-	public virtual required string Hostname { get; set; }
+	public virtual string Hostname { get; set; }
 
 	public virtual int ReferenceCount { get; set; }
 
-	public virtual required User Actor { get; set; }
+	public virtual User Actor { get; set; }
 
-	public WebAddressHost() { }
+	public WebAddressHost()
+	{
+		Hostname = null!;
+		Actor = null!;
+	}
 
 	public WebAddressHost(string hostname, User actor)
 	{
@@ -21,12 +25,12 @@ public class WebAddressHost
 		Actor = actor;
 	}
 
-	public void IncrementReferenceCount()
+	public virtual void IncrementReferenceCount()
 	{
 		ReferenceCount++;
 	}
 
-	public void DecrementReferenceCount()
+	public virtual void DecrementReferenceCount()
 	{
 		ReferenceCount--;
 	}
@@ -37,25 +41,34 @@ public class WebAddress
 {
 	public virtual int Id { get; set; }
 
-	public virtual required string Url { get; set; }
+	public virtual string Url { get; set; }
 
-	public virtual required string Scheme { get; set; }
+	public virtual string Scheme { get; set; }
 
-	public virtual required WebAddressHost Host { get; set; }
+	public virtual WebAddressHost Host { get; set; }
 
-	public virtual required int Port { get; set; }
+	public virtual int Port { get; set; }
 
-	public virtual required string Path { get; set; }
+	public virtual string Path { get; set; }
 
-	public virtual required string Query { get; set; }
+	public virtual string Query { get; set; }
 
-	public virtual required string Fragment { get; set; }
+	public virtual string Fragment { get; set; }
 
 	public virtual int ReferenceCount { get; set; }
 
-	public virtual required User Actor { get; set; }
+	public virtual User Actor { get; set; }
 
-	public WebAddress() { }
+	public WebAddress()
+	{
+		Url = null!;
+		Scheme = null!;
+		Host = null!;
+		Path = null!;
+		Query = null!;
+		Fragment = null!;
+		Actor = null!;
+	}
 
 	public WebAddress(Uri uri, WebAddressHost host, User actor)
 	{
@@ -69,13 +82,13 @@ public class WebAddress
 		Actor = actor;
 	}
 
-	public void IncrementReferenceCount()
+	public virtual void IncrementReferenceCount()
 	{
 		Host.IncrementReferenceCount();
 		ReferenceCount++;
 	}
 
-	public void DecrementReferenceCount()
+	public virtual void DecrementReferenceCount()
 	{
 		Host.DecrementReferenceCount();
 		ReferenceCount--;

--- a/VocaDbModel/Domain/WebAddress.cs
+++ b/VocaDbModel/Domain/WebAddress.cs
@@ -7,10 +7,6 @@ public class WebAddressHost
 {
 	public virtual int Id { get; set; }
 
-	public virtual DateTimeOffset CreatedAt { get; set; }
-
-	public virtual DateTimeOffset UpdatedAt { get; set; }
-
 	public virtual required string Hostname { get; set; }
 
 	public virtual int ReferenceCount { get; set; }
@@ -40,10 +36,6 @@ public class WebAddressHost
 public class WebAddress
 {
 	public virtual int Id { get; set; }
-
-	public virtual DateTimeOffset CreatedAt { get; set; }
-
-	public virtual DateTimeOffset UpdatedAt { get; set; }
 
 	public virtual required string Url { get; set; }
 

--- a/VocaDbModel/Mapping/WebAddressMap.cs
+++ b/VocaDbModel/Mapping/WebAddressMap.cs
@@ -1,0 +1,42 @@
+using FluentNHibernate.Mapping;
+using VocaDb.Model.Domain;
+
+namespace VocaDb.Model.Mapping;
+
+public class WebAddressHostMap : ClassMap<WebAddressHost>
+{
+	public WebAddressHostMap()
+	{
+		Cache.ReadWrite();
+		Id(m => m.Id);
+
+		Map(m => m.CreatedAt).Not.Nullable();
+		Map(m => m.UpdatedAt).Not.Nullable();
+		Map(m => m.Hostname).Not.Nullable();
+		Map(m => m.ReferenceCount).Not.Nullable();
+
+		References(m => m.Actor).Not.Nullable();
+	}
+}
+
+public class WebAddressMap : ClassMap<WebAddress>
+{
+	public WebAddressMap()
+	{
+		Cache.ReadWrite();
+		Id(m => m.Id);
+
+		Map(m => m.CreatedAt).Not.Nullable();
+		Map(m => m.UpdatedAt).Not.Nullable();
+		Map(m => m.Url).Not.Nullable();
+		Map(m => m.Scheme).Not.Nullable();
+		Map(m => m.Port).Not.Nullable();
+		Map(m => m.Path).Not.Nullable();
+		Map(m => m.Query).Not.Nullable();
+		Map(m => m.Fragment).Not.Nullable();
+		Map(m => m.ReferenceCount).Not.Nullable();
+
+		References(m => m.Host).Not.Nullable();
+		References(m => m.Actor).Not.Nullable();
+	}
+}

--- a/VocaDbModel/Mapping/WebAddressMap.cs
+++ b/VocaDbModel/Mapping/WebAddressMap.cs
@@ -24,12 +24,12 @@ public class WebAddressMap : ClassMap<WebAddress>
 		Cache.ReadWrite();
 		Id(m => m.Id);
 
-		Map(m => m.Url).Not.Nullable();
+		Map(m => m.Url).Length(512).Not.Nullable();
 		Map(m => m.Scheme).Not.Nullable();
 		Map(m => m.Port).Not.Nullable();
-		Map(m => m.Path).Not.Nullable();
-		Map(m => m.Query).Not.Nullable();
-		Map(m => m.Fragment).Not.Nullable();
+		Map(m => m.Path).Length(512).Not.Nullable();
+		Map(m => m.Query).Length(512).Not.Nullable();
+		Map(m => m.Fragment).Length(512).Not.Nullable();
 		Map(m => m.ReferenceCount).Not.Nullable();
 
 		References(m => m.Host).Not.Nullable();

--- a/VocaDbModel/Mapping/WebAddressMap.cs
+++ b/VocaDbModel/Mapping/WebAddressMap.cs
@@ -22,6 +22,7 @@ public class WebAddressMap : ClassMap<WebAddress>
 	public WebAddressMap()
 	{
 		Cache.ReadWrite();
+		Table("WebAddresses");
 		Id(m => m.Id);
 
 		Map(m => m.Url).Length(512).Not.Nullable();

--- a/VocaDbModel/Mapping/WebAddressMap.cs
+++ b/VocaDbModel/Mapping/WebAddressMap.cs
@@ -10,8 +10,6 @@ public class WebAddressHostMap : ClassMap<WebAddressHost>
 		Cache.ReadWrite();
 		Id(m => m.Id);
 
-		Map(m => m.CreatedAt).Not.Nullable();
-		Map(m => m.UpdatedAt).Not.Nullable();
 		Map(m => m.Hostname).Not.Nullable();
 		Map(m => m.ReferenceCount).Not.Nullable();
 
@@ -26,8 +24,6 @@ public class WebAddressMap : ClassMap<WebAddress>
 		Cache.ReadWrite();
 		Id(m => m.Id);
 
-		Map(m => m.CreatedAt).Not.Nullable();
-		Map(m => m.UpdatedAt).Not.Nullable();
 		Map(m => m.Url).Not.Nullable();
 		Map(m => m.Scheme).Not.Nullable();
 		Map(m => m.Port).Not.Nullable();

--- a/VocaDbModel/Mapping/WebLinkMap.cs
+++ b/VocaDbModel/Mapping/WebLinkMap.cs
@@ -27,6 +27,7 @@ namespace VocaDb.Model.Mapping
 			Map(m => m.Url).Length(512).Not.Nullable();
 
 			References(m => m.Entry).Column($"[{typeof(TEntry).Name}]").Not.Nullable();
+			References(m => m.Address).Nullable()/* TODO: .Not.Nullable() */;
 		}
 	}
 

--- a/VocaDbWeb/Controllers/AdminController.cs
+++ b/VocaDbWeb/Controllers/AdminController.cs
@@ -323,5 +323,12 @@ namespace VocaDb.Web.Controllers
 
 			return View("React/Index");
 		}
+
+		[Authorize]
+		public IActionResult UpdateWebAddresses()
+		{
+			Service.UpdateWebAddresses();
+			return RedirectToAction("Index");
+		}
 	}
 }

--- a/VocaDbWeb/Scripts/Pages/Admin/AdminIndex.tsx
+++ b/VocaDbWeb/Scripts/Pages/Admin/AdminIndex.tsx
@@ -95,6 +95,12 @@ const AdminIndex = (): React.ReactElement => {
 							Refresh .NET memory cache{/* LOC */}
 						</a>
 					</p>
+					{/* TODO: Remove. */}
+					<p>
+						<a href="/Admin/UpdateWebAddresses">
+							Update web addresses{/* LOC */}
+						</a>
+					</p>
 				</>
 			)}
 		</Layout>


### PR DESCRIPTION
## Overview

First step towards #710.

The new schema is taken from [yamatouta/backend/src/entities/WebAddressHost.ts](https://github.com/ycanardeau/yamatouta/blob/ba67503d3ded79c942c7240394faa1931e36f0e4/backend/src/entities/WebAddressHost.ts) and [yamatouta/backend/src/entities/WebAddress.ts](https://github.com/ycanardeau/yamatouta/blob/ba67503d3ded79c942c7240394faa1931e36f0e4/backend/src/entities/WebAddress.ts). The `ReferenceCount` should be incremented whenever a new `WebLink` is added, and decremented whenever removed. The same goes for between `WebAddresses` and `WebAddressHosts`. `Actor`s can be used for #1149 in the future.

## Current schema:

**AlbumWebLinks** table:

| Name | Data Type | Allow Nulls |
| --- | --- | --- |
| :key: Id | int | |
| Url | nvarchar(512) | |

## New schema:

**WebAddressHosts** table:

| Name | Data Type | Allow Nulls |
| --- | --- | --- |
| :key: Id | int | |
| Hostname | nvarchar(255) | |
| ReferenceCount | int | |
| Actor | int | |

**WebAddresses** table:

| Name | Data Type | Allow Nulls |
| --- | --- | --- |
| :key: Id | int | |
| Url | nvarchar(512) | |
| Scheme | nvarchar(255) | |
| Host | int | |
| Port | int | |
| Path | nvarchar(512) | |
| Query | nvarchar(512) | |
| Fragment | nvarchar(512) | |
| ReferenceCount | int | |
| Actor | int | |

**AlbumWebLinks** table:

| Name | Data Type | Allow Nulls |
| --- | --- | --- |
| :key: Id | int | |
| Address | int |

## TODOs:

```sql
select l.Url, a.Url from AlbumWebLinks l
left join WebAddresses a on l.Address = a.Id
where l.Url != a.Url
```