### PR TITLE
Hide old usernames and disabled users

### DIFF
--- a/Tests/DataContracts/Users/UserDetailsForApiContractTests.cs
+++ b/Tests/DataContracts/Users/UserDetailsForApiContractTests.cs
@@ -33,6 +33,10 @@ namespace VocaDb.Tests.DataContracts.Users
 			_user.AdditionalPermissions.AddAll(s_additionalPermissions);
 			_user.Options.LastLoginAddress = "::1";
 
+			_user.OldUsernames.Add(new OldUsername(_user, "miku"));
+			_user.OldUsernames.Add(new OldUsername(_user, "rin"));
+			_user.OldUsernames.Add(new OldUsername(_user, "luka"));
+
 			_viewer = CreateEntry.User(id: 2);
 		}
 
@@ -118,6 +122,54 @@ namespace VocaDb.Tests.DataContracts.Users
 			contract.Email.Should().Be("miku@vocadb.net");
 			contract.LastLogin.Should().Be(new DateTime(2022, 8, 31, 3, 9, 39));
 			contract.LastLoginAddress.Should().Be("::1");
+		}
+
+		[TestMethod]
+		public void LimitedUserCannotViewOldUsernames()
+		{
+			var contract = CreateContract(viewerGroup: UserGroupId.Limited);
+
+			contract.OldUsernames.Should().BeNull();
+		}
+
+		[TestMethod]
+		public void RegularUserCannotViewOldUsernames()
+		{
+			var contract = CreateContract(viewerGroup: UserGroupId.Regular);
+
+			contract.OldUsernames.Should().BeNull();
+		}
+
+		[TestMethod]
+		public void TrustedUserCannotViewOldUsernames()
+		{
+			var contract = CreateContract(viewerGroup: UserGroupId.Trusted);
+
+			contract.OldUsernames.Should().BeNull();
+		}
+
+		[TestMethod]
+		public void ModeratorCanViewOldUsernames()
+		{
+			var contract = CreateContract(viewerGroup: UserGroupId.Moderator);
+
+			contract.OldUsernames.Should().NotBeNull();
+			contract.OldUsernames.Length.Should().Be(3);
+			contract.OldUsernames[0].OldName.Should().Be("miku");
+			contract.OldUsernames[1].OldName.Should().Be("rin");
+			contract.OldUsernames[2].OldName.Should().Be("luka");
+		}
+
+		[TestMethod]
+		public void AdminCanViewOldUsernames()
+		{
+			var contract = CreateContract(viewerGroup: UserGroupId.Admin);
+
+			contract.OldUsernames.Should().NotBeNull();
+			contract.OldUsernames.Length.Should().Be(3);
+			contract.OldUsernames[0].OldName.Should().Be("miku");
+			contract.OldUsernames[1].OldName.Should().Be("rin");
+			contract.OldUsernames[2].OldName.Should().Be("luka");
 		}
 	}
 }

--- a/VocaDbModel/DataContracts/Users/ServerOnlyUserContract.cs
+++ b/VocaDbModel/DataContracts/Users/ServerOnlyUserContract.cs
@@ -12,7 +12,7 @@ namespace VocaDb.Model.DataContracts.Users
 	/// SECURITY NOTE: take care when sending to client due to the contained sensitive information.
 	/// </summary>
 	[DataContract(Namespace = Schemas.VocaDb, Name = "UserContract")]
-	public class ServerOnlyUserContract : ServerOnlyUserWithEmailContract
+	public class ServerOnlyUserContract : ServerOnlyUserWithEmailContract, IDeletableUser
 	{
 		public ServerOnlyUserContract()
 		{

--- a/VocaDbModel/DataContracts/Users/UserDetailsForApiContract.cs
+++ b/VocaDbModel/DataContracts/Users/UserDetailsForApiContract.cs
@@ -94,9 +94,6 @@ namespace VocaDb.Model.DataContracts.Users
 		[DataMember]
 		public string Name { get; set; }
 
-		[DataMember]
-		public OldUsernameContract[] OldUsernames { get; init; }
-
 		/// <summary>
 		/// List of artist entries owned by the user. Cannot be null.
 		/// </summary>
@@ -162,7 +159,6 @@ namespace VocaDb.Model.DataContracts.Users
 			Location = user.Options.Location;
 			MainPicture = iconFactory.GetUserIcons(user, ImageSizes.All);
 			Name = user.Name;
-			OldUsernames = user.OldUsernames.Select(n => new OldUsernameContract(n)).ToArray();
 
 			OwnedArtistEntries = user.OwnedArtists
 				.Select(a => new ArtistForUserForApiContract(
@@ -207,6 +203,9 @@ namespace VocaDb.Model.DataContracts.Users
 		[DataMember]
 		public string? LastLoginAddress { get; init; }
 
+		[DataMember]
+		public OldUsernameContract[]? OldUsernames { get; init; }
+
 		public UserDetailsForApiContract(
 			User user,
 			IUserIconFactory iconFactory,
@@ -229,7 +228,14 @@ namespace VocaDb.Model.DataContracts.Users
 				// SECURITY NOTE: Never include sensitive information here!
 
 				if (permissionContext.IsLoggedIn && permissionContext.LoggedUser.Id == user.Id && permissionContext.LoggedUser.Active)
+				{
 					AdditionalPermissions = user.AdditionalPermissions.PermissionTokens.Select(p => p.Id).ToArray();
+				}
+			}
+
+			if (permissionContext.HasPermission(PermissionToken.ViewOldUsernames))
+			{
+				OldUsernames = user.OldUsernames.Select(n => new OldUsernameContract(n)).ToArray();
 			}
 		}
 	}

--- a/VocaDbModel/Database/Queries/UserQueries.cs
+++ b/VocaDbModel/Database/Queries/UserQueries.cs
@@ -319,7 +319,14 @@ namespace VocaDb.Model.Database.Queries
 				var user = ctx.Query().FirstOrDefault(u => u.Name == name);
 
 				if (user is null)
+				{
 					return null;
+				}
+
+				if (!EntryPermissionManager.CanViewUser(_permissionContext, user))
+				{
+					return null;
+				}
 
 				var contract = new UserDetailsForApiContract(
 					user: user,

--- a/VocaDbModel/Domain/Security/EntryPermissionManager.cs
+++ b/VocaDbModel/Domain/Security/EntryPermissionManager.cs
@@ -240,6 +240,16 @@ namespace VocaDb.Model.Domain.Security
 			return IsVerifiedFor(permissionContext, entry);
 		}
 
+		public static bool CanViewUser(IUserPermissionContext permissionContext, IDeletableUser user)
+		{
+			if (!user.Active && !permissionContext.HasPermission(PermissionToken.ViewDisabledUsers))
+			{
+				return false;
+			}
+
+			return true;
+		}
+
 		/// <summary>
 		/// Verifies that user passes an access check for an entry.
 		/// </summary>

--- a/VocaDbModel/Domain/Security/PermissionToken.cs
+++ b/VocaDbModel/Domain/Security/PermissionToken.cs
@@ -84,6 +84,7 @@ namespace VocaDb.Model.Domain.Security
 		public static readonly PermissionToken ViewHiddenRevisions = New("c3b753d0-7aa8-4c03-8bca-5311fb2bdd2d", nameof(ViewHiddenRevisions));
 		public static readonly PermissionToken ManageWebhooks = New("838dde1d-51ba-423b-ad8e-c1e2c2024a37", nameof(ManageWebhooks));
 		public static readonly PermissionToken CreateDatabaseDump = New("d3dffb90-2408-4434-ae3a-c26352293281", nameof(CreateDatabaseDump));
+		public static readonly PermissionToken ViewOldUsernames = New("452a66b3-baa8-4ad8-8f8a-00655d37be80", nameof(ViewOldUsernames));
 
 		/// <summary>
 		/// All tokens except Nothing

--- a/VocaDbModel/Domain/Security/PermissionToken.cs
+++ b/VocaDbModel/Domain/Security/PermissionToken.cs
@@ -85,6 +85,7 @@ namespace VocaDb.Model.Domain.Security
 		public static readonly PermissionToken ManageWebhooks = New("838dde1d-51ba-423b-ad8e-c1e2c2024a37", nameof(ManageWebhooks));
 		public static readonly PermissionToken CreateDatabaseDump = New("d3dffb90-2408-4434-ae3a-c26352293281", nameof(CreateDatabaseDump));
 		public static readonly PermissionToken ViewOldUsernames = New("452a66b3-baa8-4ad8-8f8a-00655d37be80", nameof(ViewOldUsernames));
+		public static readonly PermissionToken ViewDisabledUsers = New("a3f8af3c-f39c-419c-a895-f3f73e7fa253", nameof(ViewDisabledUsers));
 
 		/// <summary>
 		/// All tokens except Nothing

--- a/VocaDbModel/Domain/Users/IUser.cs
+++ b/VocaDbModel/Domain/Users/IUser.cs
@@ -1,26 +1,30 @@
-namespace VocaDb.Model.Domain.Users
+namespace VocaDb.Model.Domain.Users;
+
+/// <summary>
+/// Interface for <see cref="User"/> with minimal information.
+/// Contains no sensitive information.
+/// </summary>
+public interface IUser
 {
-	/// <summary>
-	/// Interface for <see cref="User"/> with minimal information.
-	/// Contains no sensitive information.
-	/// </summary>
-	public interface IUser
+	int Id { get; set; }
+
+	string Name { get; set; }
+}
+
+public interface IDeletableUser : IUser
+{
+	bool Active { get; }
+}
+
+public static class IUserExtensions
+{
+	public static bool IsTheSameUser(this IUser left, IUser? right)
 	{
-		int Id { get; set; }
+		ParamIs.NotNull(() => left);
 
-		string Name { get; set; }
-	}
+		if (right == null)
+			return false;
 
-	public static class IUserExtensions
-	{
-		public static bool IsTheSameUser(this IUser left, IUser? right)
-		{
-			ParamIs.NotNull(() => left);
-
-			if (right == null)
-				return false;
-
-			return left.Id == right.Id;
-		}
+		return left.Id == right.Id;
 	}
 }

--- a/VocaDbModel/Domain/Users/User.cs
+++ b/VocaDbModel/Domain/Users/User.cs
@@ -26,7 +26,8 @@ public class User :
 	IEquatable<IUser>,
 	IWebLinkFactory<UserWebLink>,
 	IEntryWithComments,
-	IEntryImageInformation
+	IEntryImageInformation,
+	IDeletableUser
 {
 	private static readonly Logger s_log = LogManager.GetCurrentClassLogger();
 	public const string NameRegex = "^[a-zA-Z0-9_]+$";

--- a/VocaDbModel/Domain/Users/UserGroup.cs
+++ b/VocaDbModel/Domain/Users/UserGroup.cs
@@ -51,7 +51,8 @@ public class UserGroup
 		PermissionToken.ViewAuditLog,
 		PermissionToken.ViewHiddenRatings,
 		PermissionToken.ViewHiddenRevisions,
-		PermissionToken.UploadMedia
+		PermissionToken.UploadMedia,
+		PermissionToken.ViewOldUsernames
 	);
 
 	private static readonly UserGroup s_admin = new(UserGroupId.Admin,

--- a/VocaDbModel/Domain/Users/UserGroup.cs
+++ b/VocaDbModel/Domain/Users/UserGroup.cs
@@ -2,17 +2,28 @@ using VocaDb.Model.Domain.Security;
 
 namespace VocaDb.Model.Domain.Users;
 
+public enum UserGroupId
+{
+	Nothing,
+	Limited,
+	Regular,
+	Trusted,
+	Moderator,
+	Admin,
+}
+
 public class UserGroup
 {
 	/// <summary>
 	/// User group with no permissions.
 	/// </summary>
-	public static readonly UserGroup Nothing = new(UserGroupId.Nothing);
+	public static readonly UserGroup Nothing = new(id: UserGroupId.Nothing);
 
-	private static readonly UserGroup s_limited = new(UserGroupId.Limited, PermissionToken.EditProfile);
+	private static readonly UserGroup s_limited = new(id: UserGroupId.Limited, PermissionToken.EditProfile);
 
-	public static readonly UserGroup s_regular = new(UserGroupId.Regular,
-		s_limited,
+	public static readonly UserGroup s_regular = new(
+		id: UserGroupId.Regular,
+		parent: s_limited,
 		PermissionToken.CreateComments,
 		PermissionToken.ManageDatabase,
 		PermissionToken.EditTags,
@@ -20,8 +31,9 @@ public class UserGroup
 		PermissionToken.ManageEventSeries
 	);
 
-	private static readonly UserGroup s_trusted = new(UserGroupId.Trusted,
-		s_regular,
+	private static readonly UserGroup s_trusted = new(
+		id: UserGroupId.Trusted,
+		parent: s_regular,
 		PermissionToken.AddRawFileMedia,
 		PermissionToken.ApproveEntries,
 		PermissionToken.DeleteEntries,
@@ -32,8 +44,9 @@ public class UserGroup
 		PermissionToken.RemoveTagUsages
 	);
 
-	private static readonly UserGroup s_mod = new(UserGroupId.Moderator,
-		s_trusted,
+	private static readonly UserGroup s_mod = new(
+		id: UserGroupId.Moderator,
+		parent: s_trusted,
 		PermissionToken.AccessManageMenu,
 		PermissionToken.ApplyAnyTag,
 		PermissionToken.BulkDeletePVs,
@@ -52,18 +65,25 @@ public class UserGroup
 		PermissionToken.ViewHiddenRatings,
 		PermissionToken.ViewHiddenRevisions,
 		PermissionToken.UploadMedia,
-		PermissionToken.ViewOldUsernames
+		PermissionToken.ViewOldUsernames,
+		PermissionToken.ViewDisabledUsers
 	);
 
-	private static readonly UserGroup s_admin = new(UserGroupId.Admin,
-		s_mod,
+	private static readonly UserGroup s_admin = new(
+		id: UserGroupId.Admin,
+		parent: s_mod,
 		PermissionToken.Admin,
 		PermissionToken.ManageWebhooks,
 		PermissionToken.CreateDatabaseDump
 	);
 
-	private static readonly Dictionary<UserGroupId, UserGroup> s_groups = new[] {
-		s_limited, s_regular, s_trusted, s_mod, s_admin
+	private static readonly Dictionary<UserGroupId, UserGroup> s_groups = new[]
+	{
+		s_limited,
+		s_regular,
+		s_trusted,
+		s_mod,
+		s_admin,
 	}.ToDictionary(g => g.Id);
 
 	/// <summary>
@@ -110,19 +130,4 @@ public class UserGroup
 	public UserGroupId Id { get; private set; }
 
 	public PermissionCollection Permissions { get; private set; }
-}
-
-public enum UserGroupId
-{
-	Nothing,
-
-	Limited,
-
-	Regular,
-
-	Trusted,
-
-	Moderator,
-
-	Admin,
 }

--- a/VocaDbWeb/Controllers/Api/UserApiController.cs
+++ b/VocaDbWeb/Controllers/Api/UserApiController.cs
@@ -904,9 +904,10 @@ namespace VocaDb.Web.Controllers.Api
 #nullable enable
 		[HttpGet("~/api/profiles/{name}")]
 		[ApiExplorerSettings(IgnoreApi = true)]
-		public UserDetailsForApiContract? GetDetails(string name/* TODO: , int? artistId = null, bool? childVoicebanks = null */)
+		public ActionResult<UserDetailsForApiContract> GetDetails(string name/* TODO: , int? artistId = null, bool? childVoicebanks = null */)
 		{
-			return _queries.GetUserDetailsForApi(name);
+			var user = _queries.GetUserDetailsForApi(name);
+			return user is not null ? user : NotFound();
 		}
 
 		[HttpGet("current/for-my-settings")]

--- a/VocaDbWeb/Controllers/UserController.cs
+++ b/VocaDbWeb/Controllers/UserController.cs
@@ -7,20 +7,15 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Twitter;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Net.Http.Headers;
 using VocaDb.Model.Database.Queries;
 using VocaDb.Model.Database.Repositories;
-using VocaDb.Model.DataContracts.Artists;
 using VocaDb.Model.DataContracts.Users;
-using VocaDb.Model.Domain.Artists;
-using VocaDb.Model.Domain.Globalization;
 using VocaDb.Model.Domain.Security;
 using VocaDb.Model.Domain.Songs;
 using VocaDb.Model.Domain.Users;
 using VocaDb.Model.Helpers;
 using VocaDb.Model.Service;
 using VocaDb.Model.Service.Exceptions;
-using VocaDb.Model.Service.Helpers;
 using VocaDb.Model.Service.Paging;
 using VocaDb.Model.Service.QueryableExtensions;
 using VocaDb.Model.Service.Search;
@@ -279,6 +274,11 @@ namespace VocaDb.Web.Controllers
 
 			var model = Data.GetUserDetails(id);
 
+			if (!EntryPermissionManager.CanViewUser(PermissionContext, model))
+			{
+				return NotFound();
+			}
+
 			return RenderDetails(model);
 		}
 
@@ -288,6 +288,11 @@ namespace VocaDb.Web.Controllers
 
 			if (model == null)
 				return NotFound();
+
+			if (!EntryPermissionManager.CanViewUser(PermissionContext, model))
+			{
+				return NotFound();
+			}
 
 			ViewBag.ArtistId = artistId;
 			ViewBag.ChildVoicebanks = childVoicebanks;

--- a/VocaDbWeb/Scripts/DataContracts/User/UserDetailsContract.ts
+++ b/VocaDbWeb/Scripts/DataContracts/User/UserDetailsContract.ts
@@ -41,7 +41,7 @@ interface UserDetailsContractBase {
 	location: string;
 	mainPicture?: EntryThumbContract;
 	name: string;
-	oldUsernames: OldUsernameContract[];
+	oldUsernames?: OldUsernameContract[];
 	ownedArtistEntries: ArtistForUserForApiContract[];
 	possibleProducerAccount: boolean;
 	power: number;

--- a/VocaDbWeb/Scripts/Models/LoginManager.ts
+++ b/VocaDbWeb/Scripts/Models/LoginManager.ts
@@ -47,6 +47,7 @@ export enum PermissionToken {
 	ManageWebhooks = '838dde1d-51ba-423b-ad8e-c1e2c2024a37',
 	CreateDatabaseDump = 'd3dffb90-2408-4434-ae3a-c26352293281',
 	ViewOldUsernames = '452a66b3-baa8-4ad8-8f8a-00655d37be80',
+	ViewDisabledUsers = 'a3f8af3c-f39c-419c-a895-f3f73e7fa253',
 }
 
 // Corresponds to the LoginManager and EntryPermissionManager classes in C#.

--- a/VocaDbWeb/Scripts/Models/LoginManager.ts
+++ b/VocaDbWeb/Scripts/Models/LoginManager.ts
@@ -46,6 +46,7 @@ export enum PermissionToken {
 	ViewHiddenRevisions = 'c3b753d0-7aa8-4c03-8bca-5311fb2bdd2d',
 	ManageWebhooks = '838dde1d-51ba-423b-ad8e-c1e2c2024a37',
 	CreateDatabaseDump = 'd3dffb90-2408-4434-ae3a-c26352293281',
+	ViewOldUsernames = '452a66b3-baa8-4ad8-8f8a-00655d37be80',
 }
 
 // Corresponds to the LoginManager and EntryPermissionManager classes in C#.
@@ -189,6 +190,10 @@ export class LoginManager {
 
 	get canManageWebhooks(): boolean {
 		return this.hasPermission(PermissionToken.ManageWebhooks);
+	}
+
+	get canViewOldUsernames(): boolean {
+		return this.hasPermission(PermissionToken.ViewOldUsernames);
 	}
 
 	private static readonly allPermissions: EntryStatus[] = [

--- a/VocaDbWeb/Scripts/Pages/User/UserOverview.tsx
+++ b/VocaDbWeb/Scripts/Pages/User/UserOverview.tsx
@@ -249,22 +249,24 @@ const UserOverview = observer(
 						</h4>
 						{moment(user.createDate).format('l')}
 
-						{user.oldUsernames.length > 0 && (
-							<>
-								<h4 className="withMargin">
-									{t('ViewRes.User:Details.OldUsernames')}
-								</h4>
-								{user.oldUsernames.map((oldName, index) => (
-									<React.Fragment key={index}>
-										{index > 0 && ', '}
-										{oldName.oldName}{' '}
-										{t('ViewRes.User:Details.OldNameUntil', {
-											0: moment(oldName.date).format('l'),
-										})}
-									</React.Fragment>
-								))}
-							</>
-						)}
+						{loginManager.canViewOldUsernames &&
+							user.oldUsernames &&
+							user.oldUsernames.length > 0 && (
+								<>
+									<h4 className="withMargin">
+										{t('ViewRes.User:Details.OldUsernames')}
+									</h4>
+									{user.oldUsernames.map((oldName, index) => (
+										<React.Fragment key={index}>
+											{index > 0 && ', '}
+											{oldName.oldName}{' '}
+											{t('ViewRes.User:Details.OldNameUntil', {
+												0: moment(oldName.date).format('l'),
+											})}
+										</React.Fragment>
+									))}
+								</>
+							)}
 
 						{user.supporter && (
 							<div className="withMargin media">


### PR DESCRIPTION
Closes #1268.
Partially implements: #888.

This PR adds the following permissions: `ViewOldUsernames` and `ViewDisabledUser`. Mods+ have these permissions by default.