### PR TITLE
Base for Mantine Conversion

### DIFF
--- a/VocaDbWeb/Scripts/App.tsx
+++ b/VocaDbWeb/Scripts/App.tsx
@@ -11,6 +11,7 @@ import { LoginManagerProvider } from '@/LoginManagerContext';
 import { MutedUsersProvider } from '@/MutedUsersContext';
 import { VdbProvider } from '@/VdbContext';
 import '@/i18n';
+import { MantineProvider } from '@mantine/core';
 import { NostalgicDivaProvider } from '@vocadb/nostalgic-diva';
 import { ScrollToTop } from '@vocadb/route-sphere';
 import React from 'react';
@@ -42,25 +43,27 @@ const AppContainer = (): React.ReactElement => {
 
 const App = (): React.ReactElement => {
 	return (
-		<Compose
-			components={[
-				VdbProvider,
-				LoginManagerProvider,
-				BrowserRouter,
-				NostalgicDivaProvider,
-				VdbPlayerProvider,
-				MutedUsersProvider,
-			]}
-		>
-			<ScrollToTop />
-			<Header />
-			<div css={{ display: 'flex' }}>
-				<LeftMenu />
-				<AppContainer />
-			</div>
-			<Toaster containerStyle={{ top: '10vh' }} gutter={0} />
-			<VdbPlayer />
-		</Compose>
+		<MantineProvider withGlobalStyles withNormalizeCSS>
+			<Compose
+				components={[
+					VdbProvider,
+					LoginManagerProvider,
+					BrowserRouter,
+					NostalgicDivaProvider,
+					VdbPlayerProvider,
+					MutedUsersProvider,
+				]}
+			>
+				<ScrollToTop />
+				<Header />
+				<div css={{ display: 'flex' }}>
+					<LeftMenu />
+					<AppContainer />
+				</div>
+				<Toaster containerStyle={{ top: '10vh' }} gutter={0} />
+				<VdbPlayer />
+			</Compose>
+		</MantineProvider>
 	);
 };
 

--- a/VocaDbWeb/Scripts/Components/Shared/GlobalSearchBox.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/GlobalSearchBox.tsx
@@ -1,10 +1,6 @@
-import ButtonGroup from '@/Bootstrap/ButtonGroup';
-import Dropdown from '@/Bootstrap/Dropdown';
 import Navbar from '@/Bootstrap/Navbar';
 import { MainNavigationItems } from '@/Components/Shared/Partials/MainNavigationItems';
 import { ProfileIconKnockout_ImageSize } from '@/Components/Shared/Partials/User/ProfileIconKnockout_ImageSize';
-import { ShowRandomPageButton } from '@/Components/Shared/ShowRandomPageButton';
-import JQueryUIAutocomplete from '@/JQueryUI/JQueryUIAutocomplete';
 import { useLoginManager } from '@/LoginManagerContext';
 import { EntryType } from '@/Models/EntryType';
 import { ContentLanguagePreference } from '@/Models/Globalization/ContentLanguagePreference';
@@ -32,14 +28,11 @@ import { TopBarStore } from '@/Stores/TopBarStore';
 import { useVdb } from '@/VdbContext';
 import {
 	ActionIcon,
-	Anchor,
 	Badge,
 	Button,
 	Group,
 	Indicator,
-	MediaQuery,
 	Menu,
-	TextInput,
 } from '@mantine/core';
 import {
 	IconChevronDown,
@@ -300,7 +293,7 @@ export const GlobalSearchBox = observer(
 			};
 
 			await tryRedirectFuncs[topBarStore.entryType](searchTerm);
-		}, [vdb, topBarStore, navigate]);
+		}, [vdb, topBarStore, navigate, searchTerm]);
 
 		return (
 			<form
@@ -352,10 +345,10 @@ export const GlobalSearchBox = observer(
 						</Menu.Dropdown>
 					</Menu>
 					<MantineAutocomplete
-						fetchData={(val) =>
+						fetchData={(val): Promise<string[]> =>
 							globalSearchBoxSource(topBarStore.entryType, val)
 						}
-						onItemSubmit={(item) => {
+						onItemSubmit={(item): void => {
 							setSearchTerm(item.value);
 							submit();
 						}}

--- a/VocaDbWeb/Scripts/Components/Shared/MantineAutocomplete.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/MantineAutocomplete.tsx
@@ -15,7 +15,7 @@ type MantineAutocompleteProps = {
 const MantineAutocomplete = ({
 	fetchData,
 	...props
-}: MantineAutocompleteProps) => {
+}: MantineAutocompleteProps): JSX.Element => {
 	const [value, setValue] = useState('');
 	const [debounced] = useDebouncedValue(value, 100);
 	const [data, setData] = useState<FetchDataReturn>([]);
@@ -28,7 +28,7 @@ const MantineAutocomplete = ({
 		<Autocomplete
 			{...props}
 			value={value}
-			onChange={(v) => setValue(v)}
+			onChange={(v): void => setValue(v)}
 			data={data ?? []}
 		/>
 	);

--- a/VocaDbWeb/Scripts/Components/Shared/MantineAutocomplete.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/MantineAutocomplete.tsx
@@ -1,0 +1,37 @@
+import {
+	AutocompleteProps,
+	AutocompleteItem,
+	Autocomplete,
+} from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { useEffect, useState } from 'react';
+
+type FetchDataReturn = readonly (string | AutocompleteItem)[];
+
+type MantineAutocompleteProps = {
+	fetchData: (value: string) => Promise<FetchDataReturn>;
+} & Omit<AutocompleteProps, 'data'>;
+
+const MantineAutocomplete = ({
+	fetchData,
+	...props
+}: MantineAutocompleteProps) => {
+	const [value, setValue] = useState('');
+	const [debounced] = useDebouncedValue(value, 100);
+	const [data, setData] = useState<FetchDataReturn>([]);
+
+	useEffect(() => {
+		fetchData(value).then((res) => setData(res));
+	}, [debounced]);
+
+	return (
+		<Autocomplete
+			{...props}
+			value={value}
+			onChange={(v) => setValue(v)}
+			data={data ?? []}
+		/>
+	);
+};
+
+export default MantineAutocomplete;

--- a/VocaDbWeb/package-lock.json
+++ b/VocaDbWeb/package-lock.json
@@ -7,7 +7,10 @@
 			"dependencies": {
 				"@emotion/react": "^11.8.2",
 				"@fluentui/react-icons": "^2.0.179",
+				"@mantine/core": "^6.0.5",
+				"@mantine/hooks": "^6.0.5",
 				"@restart/ui": "^0.2.3",
+				"@tabler/icons-react": "^2.13.1",
 				"@vocadb/nostalgic-diva": "^1.3.0-rc.8",
 				"@vocadb/route-sphere": "^2.0.0-rc.8",
 				"@vocadb/web-link-matcher": "^1.0.0",
@@ -107,6 +110,7 @@
 			"version": "7.16.8",
 			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.8.tgz",
 			"integrity": "sha512-m7OkX0IdKLKPpBlJtF561YJal5y/jyI5fNfWbPxh2D/nbzzGI4qRyrD8xO2jB24u7l+5I2a43scCG2IrfjC50Q==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -115,6 +119,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.7.tgz",
 			"integrity": "sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==",
+			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.16.7",
 				"@babel/generator": "^7.16.7",
@@ -144,6 +149,7 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -188,6 +194,7 @@
 			"version": "7.19.6",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.6.tgz",
 			"integrity": "sha512-oHGRUQeoX1QrKeJIKVe0hwjGqNnVYsM5Nep5zo0uE0m42sLH+Fsd2pStJ5sRM1bNyTUUoz0pe2lTeMJrb/taTA==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.19.4",
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -226,6 +233,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
 			"integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.16.4",
 				"@babel/helper-validator-option": "^7.16.7",
@@ -243,6 +251,7 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -316,6 +325,7 @@
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
 			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -336,6 +346,7 @@
 			"version": "7.19.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
 			"integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.18.10",
 				"@babel/types": "^7.19.0"
@@ -348,6 +359,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
 			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.18.6"
 			},
@@ -382,6 +394,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
 			"integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
+			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.16.7",
 				"@babel/helper-module-imports": "^7.16.7",
@@ -412,6 +425,7 @@
 			"version": "7.19.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
 			"integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -450,6 +464,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
 			"integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.16.7"
 			},
@@ -473,6 +488,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
 			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.18.6"
 			},
@@ -500,6 +516,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
 			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -523,6 +540,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.7.tgz",
 			"integrity": "sha512-9ZDoqtfY7AuEOt3cxchfii6C7GDyyMBffktR5B2jvWv8u2+efwvpnVKXMWzNehqy68tKgAfSwfdw/lWpthS2bw==",
+			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.16.7",
 				"@babel/traverse": "^7.16.7",
@@ -549,6 +567,7 @@
 			"version": "7.19.6",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.6.tgz",
 			"integrity": "sha512-h1IUp81s2JYJ3mRkdxJgs4UvmSsRvDrx5ICSJbPvtWYv5i1nTBGcBpnog+89rAFMwvvru6E5NUHdBe01UeSzYA==",
+			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -982,6 +1001,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
 			"integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
+			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.18.6"
 			},
@@ -1899,6 +1919,7 @@
 			"version": "7.18.10",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
 			"integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.18.6",
 				"@babel/parser": "^7.18.10",
@@ -1912,6 +1933,7 @@
 			"version": "7.19.6",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.6.tgz",
 			"integrity": "sha512-6l5HrUCzFM04mfbG09AagtYyR2P0B71B1wN7PfSPiksDPz2k5H9CBC1tcZpz2M8OxbKTPccByoOJ22rUKbpmQQ==",
+			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.18.6",
 				"@babel/generator": "^7.19.6",
@@ -1979,26 +2001,27 @@
 			}
 		},
 		"node_modules/@emotion/babel-plugin": {
-			"version": "11.7.2",
-			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz",
-			"integrity": "sha512-6mGSCWi9UzXut/ZAN6lGFu33wGR3SJisNl3c0tvlmb8XChH1b2SUvxvnOh7hvLpqyRdHHU9AiazV3Cwbk5SXKQ==",
+			"version": "11.10.6",
+			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.6.tgz",
+			"integrity": "sha512-p2dAqtVrkhSa7xz1u/m9eHYdLi+en8NowrmXeF/dKtJpU8lCWli8RUAati7NcSl0afsBott48pdnANuD0wh9QQ==",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.12.13",
-				"@babel/plugin-syntax-jsx": "^7.12.13",
-				"@babel/runtime": "^7.13.10",
-				"@emotion/hash": "^0.8.0",
-				"@emotion/memoize": "^0.7.5",
-				"@emotion/serialize": "^1.0.2",
-				"babel-plugin-macros": "^2.6.1",
+				"@babel/helper-module-imports": "^7.16.7",
+				"@babel/runtime": "^7.18.3",
+				"@emotion/hash": "^0.9.0",
+				"@emotion/memoize": "^0.8.0",
+				"@emotion/serialize": "^1.1.1",
+				"babel-plugin-macros": "^3.1.0",
 				"convert-source-map": "^1.5.0",
 				"escape-string-regexp": "^4.0.0",
 				"find-root": "^1.1.0",
 				"source-map": "^0.5.7",
-				"stylis": "4.0.13"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
+				"stylis": "4.1.3"
 			}
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+			"integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
 		},
 		"node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -2012,15 +2035,15 @@
 			}
 		},
 		"node_modules/@emotion/cache": {
-			"version": "11.7.1",
-			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
-			"integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+			"version": "11.10.5",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
+			"integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
 			"dependencies": {
-				"@emotion/memoize": "^0.7.4",
-				"@emotion/sheet": "^1.1.0",
-				"@emotion/utils": "^1.0.0",
-				"@emotion/weak-memoize": "^0.2.5",
-				"stylis": "4.0.13"
+				"@emotion/memoize": "^0.8.0",
+				"@emotion/sheet": "^1.2.1",
+				"@emotion/utils": "^1.2.0",
+				"@emotion/weak-memoize": "^0.3.0",
+				"stylis": "4.1.3"
 			}
 		},
 		"node_modules/@emotion/hash": {
@@ -2029,67 +2052,77 @@
 			"integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
 		},
 		"node_modules/@emotion/memoize": {
-			"version": "0.7.5",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
-			"integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+			"integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
 		},
 		"node_modules/@emotion/react": {
-			"version": "11.8.2",
-			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.8.2.tgz",
-			"integrity": "sha512-+1bcHBaNJv5nkIIgnGKVsie3otS0wF9f1T1hteF3WeVvMNQEtfZ4YyFpnphGoot3ilU/wWMgP2SgIDuHLE/wAA==",
+			"version": "11.10.6",
+			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.6.tgz",
+			"integrity": "sha512-6HT8jBmcSkfzO7mc+N1L9uwvOnlcGoix8Zn7srt+9ga0MjREo6lRpuVX0kzo6Jp6oTqDhREOFsygN6Ew4fEQbw==",
 			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@emotion/babel-plugin": "^11.7.1",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/utils": "^1.1.0",
-				"@emotion/weak-memoize": "^0.2.5",
+				"@babel/runtime": "^7.18.3",
+				"@emotion/babel-plugin": "^11.10.6",
+				"@emotion/cache": "^11.10.5",
+				"@emotion/serialize": "^1.1.1",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+				"@emotion/utils": "^1.2.0",
+				"@emotion/weak-memoize": "^0.3.0",
 				"hoist-non-react-statics": "^3.3.1"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.0.0",
 				"react": ">=16.8.0"
 			},
 			"peerDependenciesMeta": {
-				"@babel/core": {
-					"optional": true
-				},
 				"@types/react": {
 					"optional": true
 				}
 			}
 		},
 		"node_modules/@emotion/serialize": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
-			"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+			"integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
 			"dependencies": {
-				"@emotion/hash": "^0.8.0",
-				"@emotion/memoize": "^0.7.4",
-				"@emotion/unitless": "^0.7.5",
-				"@emotion/utils": "^1.0.0",
+				"@emotion/hash": "^0.9.0",
+				"@emotion/memoize": "^0.8.0",
+				"@emotion/unitless": "^0.8.0",
+				"@emotion/utils": "^1.2.0",
 				"csstype": "^3.0.2"
 			}
 		},
+		"node_modules/@emotion/serialize/node_modules/@emotion/hash": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+			"integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+		},
 		"node_modules/@emotion/sheet": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
-			"integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+			"integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
 		},
 		"node_modules/@emotion/unitless": {
-			"version": "0.7.5",
-			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+			"integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
+		},
+		"node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
+			"integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
 		},
 		"node_modules/@emotion/utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.1.0.tgz",
-			"integrity": "sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
+			"integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
 		},
 		"node_modules/@emotion/weak-memoize": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
+			"integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
 		},
 		"node_modules/@eslint/eslintrc": {
 			"version": "1.3.3",
@@ -2168,6 +2201,45 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
+		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.5.tgz",
+			"integrity": "sha512-qrcbyfnRVziRlB6IYwjCopYhO7Vud750JlJyuljruIXcPxr22y8zdckcJGsuOdnQ639uVD1tTXddrcH3t3QYIQ=="
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.5.tgz",
+			"integrity": "sha512-+sAUfpQ3Frz+VCbPCqj+cZzvEESy3fjSeT/pDWkYCWOBXYNNKZfuVsHuv8/JO2zze8+Eb/Q7a6hZVgzS81fLbQ==",
+			"dependencies": {
+				"@floating-ui/core": "^1.2.4"
+			}
+		},
+		"node_modules/@floating-ui/react": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.19.2.tgz",
+			"integrity": "sha512-JyNk4A0Ezirq8FlXECvRtQOX/iBe5Ize0W/pLkrZjfHW9GUV7Xnq6zm6fyZuQzaHHqEnVizmvlA96e1/CkZv+w==",
+			"dependencies": {
+				"@floating-ui/react-dom": "^1.3.0",
+				"aria-hidden": "^1.1.3",
+				"tabbable": "^6.0.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@floating-ui/react-dom": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
+			"integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
+			"dependencies": {
+				"@floating-ui/dom": "^1.2.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
 		},
 		"node_modules/@fluentui/react-icons": {
 			"version": "2.0.179",
@@ -2977,6 +3049,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -2990,6 +3063,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -2998,6 +3072,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -3015,15 +3090,78 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.17",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
 			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
+			}
+		},
+		"node_modules/@mantine/core": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/@mantine/core/-/core-6.0.5.tgz",
+			"integrity": "sha512-jmP47Fcdw+UvcX1gDG5dNEhdF0QPeMnFZkB6JNAzaIuXKk8AVDh0rXXki0kWHx88gh/f5bGvOoRnKUb6v7UtDQ==",
+			"dependencies": {
+				"@floating-ui/react": "^0.19.1",
+				"@mantine/styles": "6.0.5",
+				"@mantine/utils": "6.0.5",
+				"@radix-ui/react-scroll-area": "1.0.2",
+				"react-remove-scroll": "^2.5.5",
+				"react-textarea-autosize": "8.3.4"
+			},
+			"peerDependencies": {
+				"@mantine/hooks": "6.0.5",
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@mantine/hooks": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-6.0.5.tgz",
+			"integrity": "sha512-PZMGYK1lwKqpyLal6il2XnE19CRWTPPwjG5r5CbL5lGAVmbucd/XhK1abTuBYzid7usJ4pIxlp/gmdcRLg14TQ==",
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@mantine/styles": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/@mantine/styles/-/styles-6.0.5.tgz",
+			"integrity": "sha512-z4G+xlf4fMFNDx0tSLXQYboyPrkv0s0oK1LFmh/cd3yoZWO9D1BF+p1eylAYAPjGdyzSg60daalWaoWR82oEiQ==",
+			"dependencies": {
+				"clsx": "1.1.1",
+				"csstype": "3.0.9"
+			},
+			"peerDependencies": {
+				"@emotion/react": ">=11.9.0",
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@mantine/styles/node_modules/clsx": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+			"integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@mantine/styles/node_modules/csstype": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
+			"integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
+		},
+		"node_modules/@mantine/utils": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/@mantine/utils/-/utils-6.0.5.tgz",
+			"integrity": "sha512-P2FVcBd2oZ9ANOsZUtTwJ4+FV6NgCRE5B7trsT8gEFUbMeQLietcsZEgAe5xhzEu9Afp5V8X8a+E9yx1blMpNg==",
+			"peerDependencies": {
+				"react": ">=16.8.0"
 			}
 		},
 		"node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -3077,6 +3215,137 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/popperjs"
+			}
+		},
+		"node_modules/@radix-ui/number": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.0.tgz",
+			"integrity": "sha512-Ofwh/1HX69ZfJRiRBMTy7rgjAzHmwe4kW9C9Y99HTRUcYLUuVT0KESFj15rPjRgKJs20GPq8Bm5aEDJ8DuA3vA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"node_modules/@radix-ui/primitive": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
+			"integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+			"integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-context": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
+			"integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-direction": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
+			"integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-presence": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
+			"integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.0",
+				"@radix-ui/react-use-layout-effect": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-primitive": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz",
+			"integrity": "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-slot": "1.0.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-scroll-area": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.2.tgz",
+			"integrity": "sha512-k8VseTxI26kcKJaX0HPwkvlNBPTs56JRdYzcZ/vzrNUkDlvXBy8sMc7WvCpYzZkHgb+hd72VW9MqkqecGtuNgg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/number": "1.0.0",
+				"@radix-ui/primitive": "1.0.0",
+				"@radix-ui/react-compose-refs": "1.0.0",
+				"@radix-ui/react-context": "1.0.0",
+				"@radix-ui/react-direction": "1.0.0",
+				"@radix-ui/react-presence": "1.0.0",
+				"@radix-ui/react-primitive": "1.0.1",
+				"@radix-ui/react-use-callback-ref": "1.0.0",
+				"@radix-ui/react-use-layout-effect": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+			"integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-use-callback-ref": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+			"integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+			"integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
 			}
 		},
 		"node_modules/@react-aria/ssr": {
@@ -3169,6 +3438,31 @@
 			"dev": true,
 			"dependencies": {
 				"@sinonjs/commons": "^1.7.0"
+			}
+		},
+		"node_modules/@tabler/icons": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-2.13.1.tgz",
+			"integrity": "sha512-hQkYW9+tnRUlnm3WDpNGLEB2FS6gyMdDb7eubmGjaWOtc9SK4CdBus465UGfx3M8FahlcOoS5BdzuaABrl/OMw==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/codecalm"
+			}
+		},
+		"node_modules/@tabler/icons-react": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-2.13.1.tgz",
+			"integrity": "sha512-YPqwdEj5T/ld5Ub00yY96rbJbys5IrmssG8f+mzSUaj3zic4DEezZhRRslRk/9gnVeUW3Qfi4p16tiBdBMdxFQ==",
+			"dependencies": {
+				"@tabler/icons": "2.13.1",
+				"prop-types": "^15.7.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/codecalm"
+			},
+			"peerDependencies": {
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/@trivago/prettier-plugin-sort-imports": {
@@ -4539,6 +4833,17 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"node_modules/aria-hidden": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+			"integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/aria-query": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
@@ -4890,28 +5195,17 @@
 			}
 		},
 		"node_modules/babel-plugin-macros": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-			"integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
 			"dependencies": {
-				"@babel/runtime": "^7.7.2",
-				"cosmiconfig": "^6.0.0",
-				"resolve": "^1.12.0"
-			}
-		},
-		"node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-			"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-			"dependencies": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.1.0",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.7.2"
+				"@babel/runtime": "^7.12.5",
+				"cosmiconfig": "^7.0.0",
+				"resolve": "^1.19.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10",
+				"npm": ">=6"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
@@ -5029,21 +5323,6 @@
 				"@babel/runtime": "^7.16.3",
 				"babel-plugin-macros": "^3.1.0",
 				"babel-plugin-transform-react-remove-prop-types": "^0.4.24"
-			}
-		},
-		"node_modules/babel-preset-react-app/node_modules/babel-plugin-macros": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.12.5",
-				"cosmiconfig": "^7.0.0",
-				"resolve": "^1.19.0"
-			},
-			"engines": {
-				"node": ">=10",
-				"npm": ">=6"
 			}
 		},
 		"node_modules/bail": {
@@ -5327,6 +5606,7 @@
 			"version": "4.19.1",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
 			"integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+			"dev": true,
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001286",
 				"electron-to-chromium": "^1.4.17",
@@ -5465,6 +5745,7 @@
 			"version": "1.0.30001423",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz",
 			"integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6111,7 +6392,6 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
 			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-			"dev": true,
 			"dependencies": {
 				"@types/parse-json": "^4.0.0",
 				"import-fresh": "^3.2.1",
@@ -6751,6 +7031,11 @@
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
 		},
+		"node_modules/detect-node-es": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+		},
 		"node_modules/diff": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -6973,7 +7258,8 @@
 		"node_modules/electron-to-chromium": {
 			"version": "1.4.46",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.46.tgz",
-			"integrity": "sha512-UtV0xUA/dibCKKP2JMxOpDtXR74zABevuUEH4K0tvduFSIoxRVcYmQsbB51kXsFTX8MmOyWMt8tuZAlmDOqkrQ=="
+			"integrity": "sha512-UtV0xUA/dibCKKP2JMxOpDtXR74zABevuUEH4K0tvduFSIoxRVcYmQsbB51kXsFTX8MmOyWMt8tuZAlmDOqkrQ==",
+			"dev": true
 		},
 		"node_modules/elliptic": {
 			"version": "6.5.4",
@@ -7169,6 +7455,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
 			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -8797,6 +9084,7 @@
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
 			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -8821,6 +9109,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-nonce": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/get-package-type": {
@@ -8902,6 +9198,7 @@
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -11922,6 +12219,7 @@
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true,
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
@@ -11955,6 +12253,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -13846,7 +14145,8 @@
 		"node_modules/node-releases": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
+			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+			"dev": true
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -14379,7 +14679,8 @@
 		"node_modules/picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"dev": true
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -15493,6 +15794,51 @@
 				"react-dom": ">=16.3.0"
 			}
 		},
+		"node_modules/react-remove-scroll": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+			"integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+			"dependencies": {
+				"react-remove-scroll-bar": "^2.3.3",
+				"react-style-singleton": "^2.2.1",
+				"tslib": "^2.1.0",
+				"use-callback-ref": "^1.3.0",
+				"use-sidecar": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-remove-scroll-bar": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+			"integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+			"dependencies": {
+				"react-style-singleton": "^2.2.1",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/react-router": {
 			"version": "6.4.3",
 			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.3.tgz",
@@ -15536,6 +15882,44 @@
 				"react": ">=16.9.0",
 				"react-dom": ">=16.9.0",
 				"sortablejs": "1"
+			}
+		},
+		"node_modules/react-style-singleton": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+			"integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+			"dependencies": {
+				"get-nonce": "^1.0.0",
+				"invariant": "^2.2.4",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-textarea-autosize": {
+			"version": "8.3.4",
+			"resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
+			"integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.10.2",
+				"use-composed-ref": "^1.3.0",
+				"use-latest": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/react-transition-group": {
@@ -16840,9 +17224,9 @@
 			}
 		},
 		"node_modules/stylis": {
-			"version": "4.0.13",
-			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
-			"integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+			"integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
 		},
 		"node_modules/supports-color": {
 			"version": "5.5.0",
@@ -16895,6 +17279,11 @@
 			"engines": {
 				"node": ">= 10"
 			}
+		},
+		"node_modules/tabbable": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.1.tgz",
+			"integrity": "sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg=="
 		},
 		"node_modules/tapable": {
 			"version": "2.2.1",
@@ -17751,6 +18140,84 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
 			"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
 			"dev": true
+		},
+		"node_modules/use-callback-ref": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+			"integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/use-composed-ref": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+			"integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/use-isomorphic-layout-effect": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+			"integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/use-latest": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+			"integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+			"dependencies": {
+				"use-isomorphic-layout-effect": "^1.1.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/use-sidecar": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+			"integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+			"dependencies": {
+				"detect-node-es": "^1.1.0",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/util": {
 			"version": "0.11.1",
@@ -18764,12 +19231,14 @@
 		"@babel/compat-data": {
 			"version": "7.16.8",
 			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.8.tgz",
-			"integrity": "sha512-m7OkX0IdKLKPpBlJtF561YJal5y/jyI5fNfWbPxh2D/nbzzGI4qRyrD8xO2jB24u7l+5I2a43scCG2IrfjC50Q=="
+			"integrity": "sha512-m7OkX0IdKLKPpBlJtF561YJal5y/jyI5fNfWbPxh2D/nbzzGI4qRyrD8xO2jB24u7l+5I2a43scCG2IrfjC50Q==",
+			"dev": true
 		},
 		"@babel/core": {
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.7.tgz",
 			"integrity": "sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.16.7",
 				"@babel/generator": "^7.16.7",
@@ -18791,7 +19260,8 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -18824,6 +19294,7 @@
 			"version": "7.19.6",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.6.tgz",
 			"integrity": "sha512-oHGRUQeoX1QrKeJIKVe0hwjGqNnVYsM5Nep5zo0uE0m42sLH+Fsd2pStJ5sRM1bNyTUUoz0pe2lTeMJrb/taTA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.19.4",
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -18853,6 +19324,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
 			"integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+			"dev": true,
 			"requires": {
 				"@babel/compat-data": "^7.16.4",
 				"@babel/helper-validator-option": "^7.16.7",
@@ -18863,7 +19335,8 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -18919,7 +19392,8 @@
 		"@babel/helper-environment-visitor": {
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
+			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+			"dev": true
 		},
 		"@babel/helper-explode-assignable-expression": {
 			"version": "7.16.7",
@@ -18934,6 +19408,7 @@
 			"version": "7.19.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
 			"integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.18.10",
 				"@babel/types": "^7.19.0"
@@ -18943,6 +19418,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
 			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.18.6"
 			}
@@ -18968,6 +19444,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
 			"integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-environment-visitor": "^7.16.7",
 				"@babel/helper-module-imports": "^7.16.7",
@@ -18991,7 +19468,8 @@
 		"@babel/helper-plugin-utils": {
 			"version": "7.19.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-			"integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw=="
+			"integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+			"dev": true
 		},
 		"@babel/helper-remap-async-to-generator": {
 			"version": "7.16.8",
@@ -19021,6 +19499,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
 			"integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.16.7"
 			}
@@ -19038,6 +19517,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
 			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.18.6"
 			}
@@ -19055,7 +19535,8 @@
 		"@babel/helper-validator-option": {
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
+			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+			"dev": true
 		},
 		"@babel/helper-wrap-function": {
 			"version": "7.16.8",
@@ -19073,6 +19554,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.7.tgz",
 			"integrity": "sha512-9ZDoqtfY7AuEOt3cxchfii6C7GDyyMBffktR5B2jvWv8u2+efwvpnVKXMWzNehqy68tKgAfSwfdw/lWpthS2bw==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.16.7",
 				"@babel/traverse": "^7.16.7",
@@ -19092,7 +19574,8 @@
 		"@babel/parser": {
 			"version": "7.19.6",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.6.tgz",
-			"integrity": "sha512-h1IUp81s2JYJ3mRkdxJgs4UvmSsRvDrx5ICSJbPvtWYv5i1nTBGcBpnog+89rAFMwvvru6E5NUHdBe01UeSzYA=="
+			"integrity": "sha512-h1IUp81s2JYJ3mRkdxJgs4UvmSsRvDrx5ICSJbPvtWYv5i1nTBGcBpnog+89rAFMwvvru6E5NUHdBe01UeSzYA==",
+			"dev": true
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
 			"version": "7.16.7",
@@ -19379,6 +19862,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
 			"integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.18.6"
 			}
@@ -20012,6 +20496,7 @@
 			"version": "7.18.10",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
 			"integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.18.6",
 				"@babel/parser": "^7.18.10",
@@ -20022,6 +20507,7 @@
 			"version": "7.19.6",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.6.tgz",
 			"integrity": "sha512-6l5HrUCzFM04mfbG09AagtYyR2P0B71B1wN7PfSPiksDPz2k5H9CBC1tcZpz2M8OxbKTPccByoOJ22rUKbpmQQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.18.6",
 				"@babel/generator": "^7.19.6",
@@ -20079,24 +20565,28 @@
 			"dev": true
 		},
 		"@emotion/babel-plugin": {
-			"version": "11.7.2",
-			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz",
-			"integrity": "sha512-6mGSCWi9UzXut/ZAN6lGFu33wGR3SJisNl3c0tvlmb8XChH1b2SUvxvnOh7hvLpqyRdHHU9AiazV3Cwbk5SXKQ==",
+			"version": "11.10.6",
+			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.6.tgz",
+			"integrity": "sha512-p2dAqtVrkhSa7xz1u/m9eHYdLi+en8NowrmXeF/dKtJpU8lCWli8RUAati7NcSl0afsBott48pdnANuD0wh9QQ==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.12.13",
-				"@babel/plugin-syntax-jsx": "^7.12.13",
-				"@babel/runtime": "^7.13.10",
-				"@emotion/hash": "^0.8.0",
-				"@emotion/memoize": "^0.7.5",
-				"@emotion/serialize": "^1.0.2",
-				"babel-plugin-macros": "^2.6.1",
+				"@babel/helper-module-imports": "^7.16.7",
+				"@babel/runtime": "^7.18.3",
+				"@emotion/hash": "^0.9.0",
+				"@emotion/memoize": "^0.8.0",
+				"@emotion/serialize": "^1.1.1",
+				"babel-plugin-macros": "^3.1.0",
 				"convert-source-map": "^1.5.0",
 				"escape-string-regexp": "^4.0.0",
 				"find-root": "^1.1.0",
 				"source-map": "^0.5.7",
-				"stylis": "4.0.13"
+				"stylis": "4.1.3"
 			},
 			"dependencies": {
+				"@emotion/hash": {
+					"version": "0.9.0",
+					"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+					"integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+				},
 				"escape-string-regexp": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -20105,15 +20595,15 @@
 			}
 		},
 		"@emotion/cache": {
-			"version": "11.7.1",
-			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
-			"integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+			"version": "11.10.5",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
+			"integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
 			"requires": {
-				"@emotion/memoize": "^0.7.4",
-				"@emotion/sheet": "^1.1.0",
-				"@emotion/utils": "^1.0.0",
-				"@emotion/weak-memoize": "^0.2.5",
-				"stylis": "4.0.13"
+				"@emotion/memoize": "^0.8.0",
+				"@emotion/sheet": "^1.2.1",
+				"@emotion/utils": "^1.2.0",
+				"@emotion/weak-memoize": "^0.3.0",
+				"stylis": "4.1.3"
 			}
 		},
 		"@emotion/hash": {
@@ -20122,55 +20612,69 @@
 			"integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
 		},
 		"@emotion/memoize": {
-			"version": "0.7.5",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
-			"integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+			"integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
 		},
 		"@emotion/react": {
-			"version": "11.8.2",
-			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.8.2.tgz",
-			"integrity": "sha512-+1bcHBaNJv5nkIIgnGKVsie3otS0wF9f1T1hteF3WeVvMNQEtfZ4YyFpnphGoot3ilU/wWMgP2SgIDuHLE/wAA==",
+			"version": "11.10.6",
+			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.6.tgz",
+			"integrity": "sha512-6HT8jBmcSkfzO7mc+N1L9uwvOnlcGoix8Zn7srt+9ga0MjREo6lRpuVX0kzo6Jp6oTqDhREOFsygN6Ew4fEQbw==",
 			"requires": {
-				"@babel/runtime": "^7.13.10",
-				"@emotion/babel-plugin": "^11.7.1",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/utils": "^1.1.0",
-				"@emotion/weak-memoize": "^0.2.5",
+				"@babel/runtime": "^7.18.3",
+				"@emotion/babel-plugin": "^11.10.6",
+				"@emotion/cache": "^11.10.5",
+				"@emotion/serialize": "^1.1.1",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+				"@emotion/utils": "^1.2.0",
+				"@emotion/weak-memoize": "^0.3.0",
 				"hoist-non-react-statics": "^3.3.1"
 			}
 		},
 		"@emotion/serialize": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
-			"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+			"integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
 			"requires": {
-				"@emotion/hash": "^0.8.0",
-				"@emotion/memoize": "^0.7.4",
-				"@emotion/unitless": "^0.7.5",
-				"@emotion/utils": "^1.0.0",
+				"@emotion/hash": "^0.9.0",
+				"@emotion/memoize": "^0.8.0",
+				"@emotion/unitless": "^0.8.0",
+				"@emotion/utils": "^1.2.0",
 				"csstype": "^3.0.2"
+			},
+			"dependencies": {
+				"@emotion/hash": {
+					"version": "0.9.0",
+					"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+					"integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+				}
 			}
 		},
 		"@emotion/sheet": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
-			"integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+			"integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
 		},
 		"@emotion/unitless": {
-			"version": "0.7.5",
-			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+			"integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
+		},
+		"@emotion/use-insertion-effect-with-fallbacks": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
+			"integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+			"requires": {}
 		},
 		"@emotion/utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.1.0.tgz",
-			"integrity": "sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
+			"integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
 		},
 		"@emotion/weak-memoize": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
+			"integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
 		},
 		"@eslint/eslintrc": {
 			"version": "1.3.3",
@@ -20231,6 +20735,37 @@
 					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 					"dev": true
 				}
+			}
+		},
+		"@floating-ui/core": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.5.tgz",
+			"integrity": "sha512-qrcbyfnRVziRlB6IYwjCopYhO7Vud750JlJyuljruIXcPxr22y8zdckcJGsuOdnQ639uVD1tTXddrcH3t3QYIQ=="
+		},
+		"@floating-ui/dom": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.5.tgz",
+			"integrity": "sha512-+sAUfpQ3Frz+VCbPCqj+cZzvEESy3fjSeT/pDWkYCWOBXYNNKZfuVsHuv8/JO2zze8+Eb/Q7a6hZVgzS81fLbQ==",
+			"requires": {
+				"@floating-ui/core": "^1.2.4"
+			}
+		},
+		"@floating-ui/react": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.19.2.tgz",
+			"integrity": "sha512-JyNk4A0Ezirq8FlXECvRtQOX/iBe5Ize0W/pLkrZjfHW9GUV7Xnq6zm6fyZuQzaHHqEnVizmvlA96e1/CkZv+w==",
+			"requires": {
+				"@floating-ui/react-dom": "^1.3.0",
+				"aria-hidden": "^1.1.3",
+				"tabbable": "^6.0.1"
+			}
+		},
+		"@floating-ui/react-dom": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
+			"integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
+			"requires": {
+				"@floating-ui/dom": "^1.2.1"
 			}
 		},
 		"@fluentui/react-icons": {
@@ -20845,6 +21380,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
 			"requires": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -20854,12 +21390,14 @@
 		"@jridgewell/resolve-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true
 		},
 		"@jridgewell/set-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true
 		},
 		"@jridgewell/source-map": {
 			"version": "0.3.2",
@@ -20874,16 +21412,64 @@
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
 			"version": "0.3.17",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
 			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"dev": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
 			}
+		},
+		"@mantine/core": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/@mantine/core/-/core-6.0.5.tgz",
+			"integrity": "sha512-jmP47Fcdw+UvcX1gDG5dNEhdF0QPeMnFZkB6JNAzaIuXKk8AVDh0rXXki0kWHx88gh/f5bGvOoRnKUb6v7UtDQ==",
+			"requires": {
+				"@floating-ui/react": "^0.19.1",
+				"@mantine/styles": "6.0.5",
+				"@mantine/utils": "6.0.5",
+				"@radix-ui/react-scroll-area": "1.0.2",
+				"react-remove-scroll": "^2.5.5",
+				"react-textarea-autosize": "8.3.4"
+			}
+		},
+		"@mantine/hooks": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-6.0.5.tgz",
+			"integrity": "sha512-PZMGYK1lwKqpyLal6il2XnE19CRWTPPwjG5r5CbL5lGAVmbucd/XhK1abTuBYzid7usJ4pIxlp/gmdcRLg14TQ==",
+			"requires": {}
+		},
+		"@mantine/styles": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/@mantine/styles/-/styles-6.0.5.tgz",
+			"integrity": "sha512-z4G+xlf4fMFNDx0tSLXQYboyPrkv0s0oK1LFmh/cd3yoZWO9D1BF+p1eylAYAPjGdyzSg60daalWaoWR82oEiQ==",
+			"requires": {
+				"clsx": "1.1.1",
+				"csstype": "3.0.9"
+			},
+			"dependencies": {
+				"clsx": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+					"integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+				},
+				"csstype": {
+					"version": "3.0.9",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
+					"integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
+				}
+			}
+		},
+		"@mantine/utils": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/@mantine/utils/-/utils-6.0.5.tgz",
+			"integrity": "sha512-P2FVcBd2oZ9ANOsZUtTwJ4+FV6NgCRE5B7trsT8gEFUbMeQLietcsZEgAe5xhzEu9Afp5V8X8a+E9yx1blMpNg==",
+			"requires": {}
 		},
 		"@nicolo-ribaudo/eslint-scope-5-internals": {
 			"version": "5.1.1-v1",
@@ -20924,6 +21510,107 @@
 			"version": "2.10.2",
 			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
 			"integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
+		},
+		"@radix-ui/number": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.0.tgz",
+			"integrity": "sha512-Ofwh/1HX69ZfJRiRBMTy7rgjAzHmwe4kW9C9Y99HTRUcYLUuVT0KESFj15rPjRgKJs20GPq8Bm5aEDJ8DuA3vA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@radix-ui/primitive": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
+			"integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@radix-ui/react-compose-refs": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+			"integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@radix-ui/react-context": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
+			"integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@radix-ui/react-direction": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
+			"integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@radix-ui/react-presence": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
+			"integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.0",
+				"@radix-ui/react-use-layout-effect": "1.0.0"
+			}
+		},
+		"@radix-ui/react-primitive": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz",
+			"integrity": "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-slot": "1.0.1"
+			}
+		},
+		"@radix-ui/react-scroll-area": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.2.tgz",
+			"integrity": "sha512-k8VseTxI26kcKJaX0HPwkvlNBPTs56JRdYzcZ/vzrNUkDlvXBy8sMc7WvCpYzZkHgb+hd72VW9MqkqecGtuNgg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/number": "1.0.0",
+				"@radix-ui/primitive": "1.0.0",
+				"@radix-ui/react-compose-refs": "1.0.0",
+				"@radix-ui/react-context": "1.0.0",
+				"@radix-ui/react-direction": "1.0.0",
+				"@radix-ui/react-presence": "1.0.0",
+				"@radix-ui/react-primitive": "1.0.1",
+				"@radix-ui/react-use-callback-ref": "1.0.0",
+				"@radix-ui/react-use-layout-effect": "1.0.0"
+			}
+		},
+		"@radix-ui/react-slot": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+			"integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.0"
+			}
+		},
+		"@radix-ui/react-use-callback-ref": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+			"integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"@radix-ui/react-use-layout-effect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+			"integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
 		},
 		"@react-aria/ssr": {
 			"version": "3.1.0",
@@ -21001,6 +21688,20 @@
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.7.0"
+			}
+		},
+		"@tabler/icons": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-2.13.1.tgz",
+			"integrity": "sha512-hQkYW9+tnRUlnm3WDpNGLEB2FS6gyMdDb7eubmGjaWOtc9SK4CdBus465UGfx3M8FahlcOoS5BdzuaABrl/OMw=="
+		},
+		"@tabler/icons-react": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-2.13.1.tgz",
+			"integrity": "sha512-YPqwdEj5T/ld5Ub00yY96rbJbys5IrmssG8f+mzSUaj3zic4DEezZhRRslRk/9gnVeUW3Qfi4p16tiBdBMdxFQ==",
+			"requires": {
+				"@tabler/icons": "2.13.1",
+				"prop-types": "^15.7.2"
 			}
 		},
 		"@trivago/prettier-plugin-sort-imports": {
@@ -22151,6 +22852,14 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"aria-hidden": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+			"integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
+			"requires": {
+				"tslib": "^2.0.0"
+			}
+		},
 		"aria-query": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
@@ -22425,27 +23134,13 @@
 			}
 		},
 		"babel-plugin-macros": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-			"integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
 			"requires": {
-				"@babel/runtime": "^7.7.2",
-				"cosmiconfig": "^6.0.0",
-				"resolve": "^1.12.0"
-			},
-			"dependencies": {
-				"cosmiconfig": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-					"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-					"requires": {
-						"@types/parse-json": "^4.0.0",
-						"import-fresh": "^3.1.0",
-						"parse-json": "^5.0.0",
-						"path-type": "^4.0.0",
-						"yaml": "^1.7.2"
-					}
-				}
+				"@babel/runtime": "^7.12.5",
+				"cosmiconfig": "^7.0.0",
+				"resolve": "^1.19.0"
 			}
 		},
 		"babel-plugin-polyfill-corejs2": {
@@ -22544,19 +23239,6 @@
 				"@babel/runtime": "^7.16.3",
 				"babel-plugin-macros": "^3.1.0",
 				"babel-plugin-transform-react-remove-prop-types": "^0.4.24"
-			},
-			"dependencies": {
-				"babel-plugin-macros": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-					"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.12.5",
-						"cosmiconfig": "^7.0.0",
-						"resolve": "^1.19.0"
-					}
-				}
 			}
 		},
 		"bail": {
@@ -22788,6 +23470,7 @@
 			"version": "4.19.1",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
 			"integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+			"dev": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30001286",
 				"electron-to-chromium": "^1.4.17",
@@ -22900,7 +23583,8 @@
 		"caniuse-lite": {
 			"version": "1.0.30001423",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz",
-			"integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ=="
+			"integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==",
+			"dev": true
 		},
 		"ccount": {
 			"version": "1.1.0",
@@ -23400,7 +24084,6 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
 			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-			"dev": true,
 			"requires": {
 				"@types/parse-json": "^4.0.0",
 				"import-fresh": "^3.2.1",
@@ -23891,6 +24574,11 @@
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
 		},
+		"detect-node-es": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+		},
 		"diff": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -24070,7 +24758,8 @@
 		"electron-to-chromium": {
 			"version": "1.4.46",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.46.tgz",
-			"integrity": "sha512-UtV0xUA/dibCKKP2JMxOpDtXR74zABevuUEH4K0tvduFSIoxRVcYmQsbB51kXsFTX8MmOyWMt8tuZAlmDOqkrQ=="
+			"integrity": "sha512-UtV0xUA/dibCKKP2JMxOpDtXR74zABevuUEH4K0tvduFSIoxRVcYmQsbB51kXsFTX8MmOyWMt8tuZAlmDOqkrQ==",
+			"dev": true
 		},
 		"elliptic": {
 			"version": "6.5.4",
@@ -24228,7 +24917,8 @@
 		"escalade": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true
 		},
 		"escape-html": {
 			"version": "1.0.3",
@@ -25422,7 +26112,8 @@
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -25439,6 +26130,11 @@
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.3"
 			}
+		},
+		"get-nonce": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
 		},
 		"get-package-type": {
 			"version": "0.1.0",
@@ -25494,7 +26190,8 @@
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true
 		},
 		"globby": {
 			"version": "10.0.2",
@@ -27730,7 +28427,8 @@
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
@@ -27757,7 +28455,8 @@
 		"json5": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true
 		},
 		"jsonfile": {
 			"version": "6.1.0",
@@ -29079,7 +29778,8 @@
 		"node-releases": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
+			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+			"dev": true
 		},
 		"normalize-path": {
 			"version": "3.0.0",
@@ -29475,7 +30175,8 @@
 		"picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"dev": true
 		},
 		"picomatch": {
 			"version": "2.3.1",
@@ -30240,6 +30941,27 @@
 				"warning": "^4.0.3"
 			}
 		},
+		"react-remove-scroll": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+			"integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+			"requires": {
+				"react-remove-scroll-bar": "^2.3.3",
+				"react-style-singleton": "^2.2.1",
+				"tslib": "^2.1.0",
+				"use-callback-ref": "^1.3.0",
+				"use-sidecar": "^1.1.2"
+			}
+		},
+		"react-remove-scroll-bar": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+			"integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+			"requires": {
+				"react-style-singleton": "^2.2.1",
+				"tslib": "^2.0.0"
+			}
+		},
 		"react-router": {
 			"version": "6.4.3",
 			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.3.tgz",
@@ -30264,6 +30986,26 @@
 			"requires": {
 				"classnames": "2.3.1",
 				"tiny-invariant": "1.2.0"
+			}
+		},
+		"react-style-singleton": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+			"integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+			"requires": {
+				"get-nonce": "^1.0.0",
+				"invariant": "^2.2.4",
+				"tslib": "^2.0.0"
+			}
+		},
+		"react-textarea-autosize": {
+			"version": "8.3.4",
+			"resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
+			"integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+			"requires": {
+				"@babel/runtime": "^7.10.2",
+				"use-composed-ref": "^1.3.0",
+				"use-latest": "^1.2.1"
 			}
 		},
 		"react-transition-group": {
@@ -31309,9 +32051,9 @@
 			}
 		},
 		"stylis": {
-			"version": "4.0.13",
-			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
-			"integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+			"integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
 		},
 		"supports-color": {
 			"version": "5.5.0",
@@ -31348,6 +32090,11 @@
 					"dev": true
 				}
 			}
+		},
+		"tabbable": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.1.tgz",
+			"integrity": "sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg=="
 		},
 		"tapable": {
 			"version": "2.2.1",
@@ -31933,6 +32680,43 @@
 					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
 					"dev": true
 				}
+			}
+		},
+		"use-callback-ref": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+			"integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+			"requires": {
+				"tslib": "^2.0.0"
+			}
+		},
+		"use-composed-ref": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+			"integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+			"requires": {}
+		},
+		"use-isomorphic-layout-effect": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+			"integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+			"requires": {}
+		},
+		"use-latest": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+			"integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+			"requires": {
+				"use-isomorphic-layout-effect": "^1.1.1"
+			}
+		},
+		"use-sidecar": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+			"integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+			"requires": {
+				"detect-node-es": "^1.1.0",
+				"tslib": "^2.0.0"
 			}
 		},
 		"util": {

--- a/VocaDbWeb/package.json
+++ b/VocaDbWeb/package.json
@@ -57,7 +57,10 @@
 	"dependencies": {
 		"@emotion/react": "^11.8.2",
 		"@fluentui/react-icons": "^2.0.179",
+		"@mantine/core": "^6.0.5",
+		"@mantine/hooks": "^6.0.5",
 		"@restart/ui": "^0.2.3",
+		"@tabler/icons-react": "^2.13.1",
 		"@vocadb/nostalgic-diva": "^1.3.0-rc.8",
 		"@vocadb/route-sphere": "^2.0.0-rc.8",
 		"@vocadb/web-link-matcher": "^1.0.0",


### PR DESCRIPTION
Start of #851. @ycanardeau and I decided that it would be best to do the frontend migration with Mantine instead of Bootstrap 5. This PR is just an example how one incremental step in the migration process might look like and to gather feedback on how this process should be structured. 

One unsolved problem is if and how an UI switch should be implemented. Maybe we could use the existing theme mechanics to optionally load the bootstrap css, but I don't have enough insight to determine if this is a viable solution.
Or maybe the best solution is to just do the migration in a separate branch and to merge once the migration is finished.

![Screenshot from 2023-04-02 18-46-46](https://user-images.githubusercontent.com/65015656/229381357-5512c2a9-6eab-4f65-bec1-b7d000c34401.png)
(Obviously this still needs some improvements like colors and a better layout, but it shows that a conversion to Mantine is feasible) 

The benefits of a conversion would be:

1. Improved developer experience
2. Improved accessibility
3. Improved responsiveness
4. (Improved performance)
 