### PR TITLE
bilibili, fix unhandled exception for unviewable videos

### DIFF
--- a/VocaDbModel/Service/VideoServices/VideoServiceBilibili.cs
+++ b/VocaDbModel/Service/VideoServices/VideoServiceBilibili.cs
@@ -50,9 +50,9 @@ public class VideoServiceBilibili : VideoService
 			return VideoUrlParseResult.CreateError(url, VideoUrlParseResultType.LoadError, new VideoParseException($"Unable to load Bilibili URL: {x.Message}", x));
 		}
 
-		// cannot view video
+		// If the video cannot be viewed,
 		// web returns the error message "啊叻？视频不见了？" (あれ? the video's gone?)
-		// api simultaneously returns the message "稿件不可见" (upload cannot be viewed)
+		// API simultaneously returns the message "稿件不可见" (upload cannot be viewed)
 		if (response.Code == 62002)
 		{
 			return VideoUrlParseResult.CreateError(url, VideoUrlParseResultType.LoadError, "Video cannot be viewed");

--- a/VocaDbModel/Service/VideoServices/VideoServiceBilibili.cs
+++ b/VocaDbModel/Service/VideoServices/VideoServiceBilibili.cs
@@ -53,7 +53,7 @@ public class VideoServiceBilibili : VideoService
 		// If the video cannot be viewed,
 		// web returns the error message "啊叻？视频不见了？" (あれ? the video's gone?)
 		// API simultaneously returns the message "稿件不可见" (upload cannot be viewed)
-		if (response.Code == 62002)
+		if (response == null || response.Data == null || response.Code == 62002)
 		{
 			return VideoUrlParseResult.CreateError(url, VideoUrlParseResultType.LoadError, "Video cannot be viewed");
 		}
@@ -114,7 +114,7 @@ public class BiliMetadata
 class BilibiliResponse
 {
 	public int Code { get; init; } = default!;
-	public BilibiliResponseData Data { get; init; } = default!;
+	public BilibiliResponseData? Data { get; init; } = default;
 }
 
 class BilibiliResponseData

--- a/VocaDbModel/Service/VideoServices/VideoServiceBilibili.cs
+++ b/VocaDbModel/Service/VideoServices/VideoServiceBilibili.cs
@@ -50,6 +50,14 @@ public class VideoServiceBilibili : VideoService
 			return VideoUrlParseResult.CreateError(url, VideoUrlParseResultType.LoadError, new VideoParseException($"Unable to load Bilibili URL: {x.Message}", x));
 		}
 
+		// cannot view video
+		// web returns the error message "啊叻？视频不见了？" (あれ? the video's gone?)
+		// api simultaneously returns the message "稿件不可见" (upload cannot be viewed)
+		if (response.Code == 62002)
+		{
+			return VideoUrlParseResult.CreateError(url, VideoUrlParseResultType.LoadError, "Video cannot be viewed");
+		}
+
 		var authorId = response.Data.Owner.Mid.ToString();
 		var aid = response.Data.Aid;
 		var bvid = response.Data.Bvid;
@@ -105,6 +113,7 @@ public class BiliMetadata
 
 class BilibiliResponse
 {
+	public int Code { get; init; } = default!;
 	public BilibiliResponseData Data { get; init; } = default!;
 }
 


### PR DESCRIPTION
I am not familiar with C# so this code needs a good review first.

https://vocadb.net/api/pvs and https://vocadb.net/api/songs/findDuplicate would return "Sorry, an unhandled error occurred :(" instead of expected JSON data.

The log was like this:

```
[.NET ThreadPool Worker] INFO Loading Bilibili URL http://bilibili.com/video/av575832 
[.NET ThreadPool Worker] ERROR An unhandled exception has occurred while executing the request. - System.NullReferenceException Object reference not set to an instance of an object. Void MoveNext()    at VocaDb.Model.Service.VideoServices.VideoServiceBilibili.ParseByUrlAsync(String url, Boolean getTitle) in /tmp/vocadb-dev/git/vocadb/VocaDbModel/Service/VideoServices/VideoServiceBilibili.cs:line 53
   at VocaDb.Model.Database.Queries.SongQueries.FindDuplicates(String[] anyName, String[] anyPv, Int32[] artistIds, Boolean getPVInfo) in /tmp/vocadb-dev/git/vocadb/VocaDbModel/Database/Queries/SongQueries.cs:line 946
   at VocaDb.Web.Controllers.Api.SongApiController.GetFindDuplicate(String[] term, String[] pv, Int32[] artistIds, Boolean getPVInfo) in /tmp/vocadb-dev/git/vocadb/VocaDbWeb/Controllers/Api/SongApiController.cs:line 127
   at lambda_method1024(Closure, Object)

[...]
```