### PR TITLE
Minor improvements in Japanese

### DIFF
--- a/VocaDbWeb/public/locales/ja/ViewRes.User.json
+++ b/VocaDbWeb/public/locales/ja/ViewRes.User.json
@@ -206,10 +206,10 @@
   },
   "RequestVerification": {
     "ArtistTitle": "証明するアーティスト項目（必須）",
-    "Login": "ログオン",
+    "Login": "ログイン",
     "MessageTitle": "追加メッセージ（任意）",
     "NoPrivateMessage": "証明を以下のURLで提出",
-    "NotLoggedInMessage": "これを使う前に<1>ログオン</1>するか<2>登録</2>してください。",
+    "NotLoggedInMessage": "これを使う前に<1>ログイン</1>するか<2>登録</2>してください。",
     "PageTitle": "アーティストアカウント証明",
     "PrivateMessage": "証明をダイレクトメッセージで提出",
     "Send": "送信",


### PR DESCRIPTION
This is a pull request for minor Japanese improvements.
There was a slight difference in Japanese on some pages (login page for artists).

- 'ログオン' -> 'ログイン'

Current Japanese web site applications do not display 'ログオン'.

Thank you. 😊