### PR TITLE
Final language field fixes

### DIFF
--- a/VocaDbWeb/Controllers/Api/SongApiController.cs
+++ b/VocaDbWeb/Controllers/Api/SongApiController.cs
@@ -476,10 +476,10 @@ public class SongApiController : ApiController
 	[ApiExplorerSettings(IgnoreApi = true)]
 	public async Task<IEnumerable<TagUsageForApiContract>> GetTagSuggestions(int id) =>
 		await _queries.GetTagSuggestionsAsync(id);
-	
+
 	[HttpGet("{id:int}/tagUsages")]
 	[ApiExplorerSettings(IgnoreApi = true)]
-	public EntryWithTagUsagesForApiContract GetTagUsages(int id)  => _service.GetEntryWithTagUsages(id);
+	public EntryWithTagUsagesForApiContract GetTagUsages(int id) => _service.GetEntryWithTagUsages(id);
 
 	/// <summary>
 	/// Gets top rated songs.
@@ -682,6 +682,9 @@ public class SongApiController : ApiController
 		{
 			return ValidationProblem(ModelState);
 		}
+
+		// We only need unique culture codes
+		contract.CultureCodes = contract.CultureCodes.Distinct().ToArray();
 
 		await _queries.UpdateBasicProperties(contract);
 

--- a/VocaDbWeb/Scripts/Pages/Artist/ArtistBasicInfo.tsx
+++ b/VocaDbWeb/Scripts/Pages/Artist/ArtistBasicInfo.tsx
@@ -445,8 +445,10 @@ const ArtistBasicInfo = observer(
 													{artist.advancedStats.topLanguages
 														.map(
 															(c) =>
-																getCodeDescription(c.data)?.englishName ??
-																t('ViewRes.Song:Details.LyricsLanguageOther'),
+																`${
+																	getCodeDescription(c.data)?.englishName ??
+																	t('ViewRes.Song:Details.LyricsLanguageOther')
+																} (${c.count})`,
 														)
 														.join(', ')}
 												</>

--- a/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
@@ -82,6 +82,7 @@ const BasicInfoTabContent = observer(
 			'Resources',
 			'ViewRes',
 			'ViewRes.Song',
+			'VocaDb.Web.Resources.Domain.Globalization',
 			'VocaDb.Model.Resources',
 		]);
 
@@ -403,9 +404,12 @@ const BasicInfoTabContent = observer(
 				<div className="editor-field">
 					<tbody>
 						{songEditStore.cultureCodes.items.map((c, index) => (
-							<tr>
+							<tr key={index}>
 								<UserLanguageCultureDropdownList
 									value={c.toString()}
+									placeholder={t(
+										'VocaDb.Web.Resources.Domain.Globalization:InterfaceLanguage.Other',
+									)}
 									extended={songEditStore.cultureCodes.extended}
 									onChange={(val): void => {
 										songEditStore.cultureCodes.items[index] = val.target.value;

--- a/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
@@ -427,13 +427,15 @@ const BasicInfoTabContent = observer(
 							</tr>
 						))}
 					</tbody>
-					<SafeAnchor
-						href="#"
-						className="textLink addLink"
-						onClick={(): void => songEditStore.cultureCodes.add()}
-					>
-						{t('ViewRes:Shared.Add')}
-					</SafeAnchor>
+					{songEditStore.cultureCodes.items.length < 3 && (
+						<SafeAnchor
+							href="#"
+							className="textLink addLink"
+							onClick={(): void => songEditStore.cultureCodes.add()}
+						>
+							{t('ViewRes:Shared.Add')}
+						</SafeAnchor>
+					)}
 					{!songEditStore.cultureCodes.extended &&
 						songEditStore.cultureCodes.items.length > 0 && (
 							<SafeAnchor


### PR DESCRIPTION
- [x] A new language gets set to "Other/Unknown" by default now (this fixes "German" being shown as "Other")
- [x] The amount of languages is restricted to 3
- [x] Multiple culture codes get reduced to only distinct culture codes
- [x] Top languages show the amount of uses now