### PR TITLE
refactor: Update /api/activityEntries

### DIFF
--- a/VocaDbModel/Database/Queries/ActivityEntryQueries.cs
+++ b/VocaDbModel/Database/Queries/ActivityEntryQueries.cs
@@ -125,7 +125,6 @@ public class ActivityEntryQueries
 				.OrderBy(sortRule)
 				.Take(maxResults)
 				.ToArray()
-				.Where(a => !a.EntryBase.Deleted)
 				.Select(a => new ActivityEntryForApiContract(
 					a,
 					fields.HasFlag(ActivityEntryOptionalFields.Entry)

--- a/VocaDbModel/Service/ArtistService.cs
+++ b/VocaDbModel/Service/ArtistService.cs
@@ -70,6 +70,8 @@ public class ArtistService : ServiceBase
 			NHibernateUtil.Initialize(a.Picture);
 			a.Delete();
 
+			AddEntryEditedEntry(session, a, Domain.Activityfeed.EntryEditEvent.Deleted, null);
+
 			Archive(session, a, new ArtistDiff(false), ArtistArchiveReason.Deleted, notes);
 		}, PermissionToken.Nothing, skipLog: true);
 	}

--- a/VocaDbModel/Service/OtherService.cs
+++ b/VocaDbModel/Service/OtherService.cs
@@ -381,7 +381,8 @@ public class OtherService : ServiceBase
 
 	public async Task<FrontPageForApiContract> GetFrontPageForApiContent()
 	{
-		const int maxActivityEntries = 15;
+		const int maxFetchActivityEntries = 60;
+		const int maxDisplayedActivityEntries = 15;
 
 		return await HandleQueryAsync(async session =>
 		{
@@ -389,9 +390,11 @@ public class OtherService : ServiceBase
 			// See also: https://github.com/VocaDB/vocadb/pull/663#pullrequestreview-545596680
 			var activityEntries = (await session.Query<ActivityEntry>()
 				.OrderByDescending(a => a.CreateDate)
-				.Take(maxActivityEntries)
+				.Take(maxFetchActivityEntries)
 				.ToListAsync())
-				.Where(a => !a.EntryBase.Deleted);
+				.Where(a => !a.EntryBase.Deleted)
+				.DistinctBy(a => new { EID = a.EntryBase.Id, AID = a.Author.Id })
+				.Take(maxDisplayedActivityEntries);
 
 			var newAlbums = GetRecentAlbums(
 				session: session,

--- a/VocaDbModel/Service/Queries/ActivityEntryQueries.cs
+++ b/VocaDbModel/Service/Queries/ActivityEntryQueries.cs
@@ -22,14 +22,6 @@ public class ActivityEntryQueries
 
 	public void AddActivityfeedEntry(ActivityEntry entry)
 	{
-		var latestEntries = _ctx.Query()
-			.OrderByDescending(a => a.CreateDate)
-			.Take(10)   // time cutoff would be better instead of an arbitrary number of activity entries
-			.ToArray();
-
-		if (latestEntries.Any(e => e.IsDuplicate(entry)))
-			return;
-
 		_ctx.Save(entry);
 	}
 

--- a/VocaDbModel/Service/ServiceBase.cs
+++ b/VocaDbModel/Service/ServiceBase.cs
@@ -64,14 +64,6 @@ public abstract class ServiceBase
 
 	protected void AddActivityfeedEntry(ISession session, ActivityEntry entry)
 	{
-		var latestEntries = session.Query<ActivityEntry>()
-			.OrderByDescending(a => a.CreateDate)
-			.Take(10)   // time cutoff would be better instead of an arbitrary number of activity entries
-			.ToArray();
-
-		if (latestEntries.Any(e => e.IsDuplicate(entry)))
-			return;
-
 		session.Save(entry);
 	}
 

--- a/VocaDbModel/Service/SongService.cs
+++ b/VocaDbModel/Service/SongService.cs
@@ -84,13 +84,15 @@ public class SongService : ServiceBase
 
 	public void Delete(int id, string notes)
 	{
-		UpdateEntity<Song>(id, (session, song) =>
+		UpdateEntity<Song>(id, async (session, song) =>
 		{
 			EntryPermissionManager.VerifyDelete(PermissionContext, song);
 
 			AuditLog($"deleting song {EntryLinkFactory.CreateEntryLink(song)}", session);
 
 			song.Delete();
+
+			AddEntryEditedEntry(session, song, Domain.Activityfeed.EntryEditEvent.Deleted, null);
 
 			Archive(session, song, new SongDiff(false), SongArchiveReason.Deleted, notes);
 		}, PermissionToken.Nothing, skipLog: true);


### PR DESCRIPTION
Currently `/api/activityEntries` automatically deduplicates activity entries and doesn't contain deletion events. This is somewhat unexpected for some api users who expect this endpoint to be a stream of all database updates. The frontpage activity entry section is separate from this endpoint and will continue to function normally.