### PR TITLE
feat: Allow multiple release events for albums

### DIFF
--- a/VocaDbModel/DataContracts/Albums/AlbumForApiContract.cs
+++ b/VocaDbModel/DataContracts/Albums/AlbumForApiContract.cs
@@ -112,6 +112,13 @@ public class AlbumForApiContract : IEntryBase
 					thumbPersister
 				)
 				: null;
+			ReleaseEvents = album.OriginalRelease != null ? album.OriginalRelease.ReleaseEvents.Select(e => new ReleaseEventForApiContract(
+				e,
+				languagePreference,
+				permissionContext,
+				ReleaseEventOptionalFields.None,
+				thumbPersister
+			)).ToArray() : Array.Empty<ReleaseEventForApiContract>();
 		}
 
 		if (fields.HasFlag(AlbumOptionalFields.Tags))
@@ -248,6 +255,9 @@ public class AlbumForApiContract : IEntryBase
 	/// </summary>
 	[DataMember]
 	public ReleaseEventForApiContract? ReleaseEvent { get; init; }
+
+	[DataMember]
+	public ReleaseEventForApiContract[] ReleaseEvents { get; init; }
 
 	[DataMember]
 	public EntryStatus Status { get; init; }

--- a/VocaDbModel/DataContracts/Albums/AlbumReleaseContract.cs
+++ b/VocaDbModel/DataContracts/Albums/AlbumReleaseContract.cs
@@ -21,7 +21,13 @@ public sealed class AlbumReleaseContract : IAlbumRelease
 	[DataMember]
 	public ReleaseEventForApiContract? ReleaseEvent { get; init; }
 
-	public AlbumReleaseContract() { }
+	[DataMember]
+	public ReleaseEventForApiContract[] ReleaseEvents { get; init; }
+
+	public AlbumReleaseContract()
+	{
+		ReleaseEvents = Array.Empty<ReleaseEventForApiContract>();
+	}
 
 	public AlbumReleaseContract(
 		AlbumRelease release,
@@ -46,5 +52,13 @@ public sealed class AlbumReleaseContract : IAlbumRelease
 				null
 			)
 			: null;
+
+		ReleaseEvents = release.ReleaseEvents.Select(e => new ReleaseEventForApiContract(
+			e,
+			languagePreference,
+			permissionContext,
+			ReleaseEventOptionalFields.None,
+			null
+		)).ToArray();
 	}
 }

--- a/VocaDbModel/DataContracts/Albums/ArchivedAlbumReleaseContract.cs
+++ b/VocaDbModel/DataContracts/Albums/ArchivedAlbumReleaseContract.cs
@@ -19,6 +19,7 @@ public class ArchivedAlbumReleaseContract : IAlbumRelease
 		ReleaseDate = release.ReleaseDate != null ? new OptionalDateTimeContract(release.ReleaseDate) : null;
 
 		ReleaseEvent = ObjectRefContract.Create(release.ReleaseEvent);
+		ReleaseEvents = release.ReleaseEvents.Select(e => ObjectRefContract.Create(e)).ToArray();
 	}
 
 	[DataMember]
@@ -31,4 +32,7 @@ public class ArchivedAlbumReleaseContract : IAlbumRelease
 
 	[DataMember]
 	public ObjectRefContract? ReleaseEvent { get; init; }
+
+	[DataMember]
+	public ObjectRefContract[]? ReleaseEvents { get; init; }
 }

--- a/VocaDbModel/Database/Queries/AlbumQueries.cs
+++ b/VocaDbModel/Database/Queries/AlbumQueries.cs
@@ -891,9 +891,20 @@ public class AlbumQueries : QueriesBase<IAlbumRepository, Album>
 			}
 
 			// Original release
-			album.OriginalRelease = fullProperties.OriginalRelease != null
-				? new AlbumRelease(fullProperties.OriginalRelease, fullProperties.OriginalRelease.ReleaseEvents.Select(e => session.NullSafeLoad<ReleaseEvent>(e)).ToArray())
-				: null;
+			if (fullProperties.OriginalRelease != null)
+			{
+				if (fullProperties.OriginalRelease.ReleaseEvents != null)
+				{
+					album.OriginalRelease =
+						 new AlbumRelease(fullProperties.OriginalRelease, fullProperties.OriginalRelease.ReleaseEvents.Select(e => session.NullSafeLoad<ReleaseEvent>(e)).ToArray());
+				}
+				else if (fullProperties.OriginalRelease.ReleaseEvent != null)
+				{
+
+					album.OriginalRelease =
+						 new AlbumRelease(fullProperties.OriginalRelease, new ReleaseEvent[] { session.NullSafeLoad<ReleaseEvent>(fullProperties.OriginalRelease.ReleaseEvent) });
+				}
+			}
 
 			// Artists
 			DatabaseContextHelper.RestoreObjectRefs(

--- a/VocaDbModel/Database/Queries/EventQueries.cs
+++ b/VocaDbModel/Database/Queries/EventQueries.cs
@@ -485,7 +485,7 @@ public class EventQueries : QueriesBase<IEventRepository, ReleaseEvent>
 
 			foreach (var song in entry.AllSongs)
 			{
-				song.ReleaseEvent = null;
+				song.ReleaseEvents = song.ReleaseEvents.Where(e => e.Id != eventId).ToList();
 			}
 
 			var ctxActivity = ctx.OfType<ReleaseEventActivityEntry>();

--- a/VocaDbModel/Database/Queries/SongQueries.cs
+++ b/VocaDbModel/Database/Queries/SongQueries.cs
@@ -1103,6 +1103,7 @@ public class SongQueries : QueriesBase<ISongRepository, Song>
 			}
 
 			target.ReleaseEvent ??= source.ReleaseEvent;
+			target.ReleaseEvents = target.ReleaseEvents.Concat(source.ReleaseEvents).Distinct().ToArray();
 
 			// Create merge record
 			var mergeEntry = new SongMergeRecord(source, target);

--- a/VocaDbModel/Database/Queries/SongQueries.cs
+++ b/VocaDbModel/Database/Queries/SongQueries.cs
@@ -1366,7 +1366,7 @@ public class SongQueries : QueriesBase<ISongRepository, Song>
 			if (webLinkDiff.Changed)
 				diff.WebLinks.Set();
 
-			var newReleaseEvents = properties.ReleaseEvents.Select(e => new CreateEventQuery().FindOrCreate(ctx, PermissionContext, e, song));
+			var newReleaseEvents = properties.ReleaseEvents.DistinctBy(e => e.Id).Select(e => new CreateEventQuery().FindOrCreate(ctx, PermissionContext, e, song));
 			if (!song.ReleaseEvents.SequenceEqual(newReleaseEvents))
 			{
 				song.ReleaseEvents = newReleaseEvents.ToArray();

--- a/VocaDbModel/Domain/Albums/AlbumRelease.cs
+++ b/VocaDbModel/Domain/Albums/AlbumRelease.cs
@@ -5,10 +5,11 @@ namespace VocaDb.Model.Domain.Albums;
 public class AlbumRelease : IAlbumRelease
 {
 	private string? _catNum;
+	private IList<ReleaseEvent> _releaseEvents = new List<ReleaseEvent>();
 
 	public AlbumRelease() { }
 
-	public AlbumRelease(IAlbumRelease contract, ReleaseEvent? releaseEvent)
+	public AlbumRelease(IAlbumRelease contract, ReleaseEvent[] releaseEvents)
 	{
 		ParamIs.NotNull(() => contract);
 
@@ -18,7 +19,7 @@ public class AlbumRelease : IAlbumRelease
 			? OptionalDateTime.Create(contract.ReleaseDate)
 			: null;
 
-		ReleaseEvent = releaseEvent;
+		ReleaseEvents = releaseEvents;
 	}
 
 	public virtual string? CatNum
@@ -42,12 +43,21 @@ public class AlbumRelease : IAlbumRelease
 	IOptionalDateTime? IAlbumRelease.ReleaseDate => ReleaseDate;
 
 	public virtual ReleaseEvent? ReleaseEvent { get; set; }
+	public virtual IList<ReleaseEvent> ReleaseEvents
+	{
+		get => _releaseEvents;
+		set
+		{
+			ParamIs.NotNull(() => value);
+			_releaseEvents = value;
+		}
+	}
 
 	public virtual bool Equals(AlbumRelease? another)
 	{
 		if (another == null)
 			return IsEmpty;
 
-		return Equals(CatNum, another.CatNum) && Equals(ReleaseDate, another.ReleaseDate) && Equals(ReleaseEvent, another.ReleaseEvent);
+		return Equals(CatNum, another.CatNum) && Equals(ReleaseDate, another.ReleaseDate) && ReleaseEvents.SequenceEqual(another.ReleaseEvents);
 	}
 }

--- a/VocaDbModel/Mapping/Albums/AlbumMap.cs
+++ b/VocaDbModel/Mapping/Albums/AlbumMap.cs
@@ -51,6 +51,7 @@ public class AlbumMap : ClassMap<Album>
 		{
 			c.Map(m => m.CatNum, "ReleaseCatNum");
 			c.References(m => m.ReleaseEvent).Nullable();
+			c.HasManyToMany(m => m.ReleaseEvents).Table("ReleaseEventsForEntries").ParentKeyColumn("Album").ChildKeyColumn("ReleaseEvent").LazyLoad().Cascade.All().Cache.ReadWrite();
 			c.Component(m => m.ReleaseDate, c2 =>
 			{
 				c2.Map(m => m.Year, "ReleaseYear");

--- a/VocaDbWeb/Scripts/Bootstrap/AbstractNav.tsx
+++ b/VocaDbWeb/Scripts/Bootstrap/AbstractNav.tsx
@@ -21,55 +21,53 @@ interface AbstractNavProps
 	parentOnSelect?: SelectCallback;
 }
 
-const AbstractNav: BsPrefixRefForwardingComponent<
-	'ul',
-	AbstractNavProps
-> = React.forwardRef<HTMLElement, AbstractNavProps>(
-	(
-		{
-			// Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
-			as: Component = 'ul',
-			onSelect,
-			activeKey,
-			role,
-			onKeyDown,
-			...props
+const AbstractNav: BsPrefixRefForwardingComponent<'ul', AbstractNavProps> =
+	React.forwardRef<HTMLElement, AbstractNavProps>(
+		(
+			{
+				// Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
+				as: Component = 'ul',
+				onSelect,
+				activeKey,
+				role,
+				onKeyDown,
+				...props
+			},
+			ref,
+		) => {
+			const parentOnSelect = useContext(SelectableContext);
+			const tabContext = useContext(TabContext);
+
+			let getControlledId, getControllerId;
+
+			if (tabContext) {
+				role = role || 'tablist';
+				activeKey = tabContext.activeKey;
+				getControlledId = tabContext.getControlledId;
+				getControllerId = tabContext.getControllerId;
+			}
+
+			const handleSelect = (key: any, event: any): void => {
+				//if (key == null) return;
+				onSelect?.(key, event);
+				parentOnSelect?.(key, event);
+			};
+
+			return (
+				<SelectableContext.Provider value={handleSelect}>
+					<NavContext.Provider
+						value={{
+							role, // used by NavLink to determine it's role
+							activeKey: makeEventKey(activeKey),
+							getControlledId: getControlledId || noop,
+							getControllerId: getControllerId || noop,
+						}}
+					>
+						<Component {...props} ref={ref} role={role} />
+					</NavContext.Provider>
+				</SelectableContext.Provider>
+			);
 		},
-		ref,
-	) => {
-		const parentOnSelect = useContext(SelectableContext);
-		const tabContext = useContext(TabContext);
-
-		let getControlledId, getControllerId;
-
-		if (tabContext) {
-			role = role || 'tablist';
-			activeKey = tabContext.activeKey;
-			getControlledId = tabContext.getControlledId;
-			getControllerId = tabContext.getControllerId;
-		}
-
-		const handleSelect = (key: any, event: any): void => {
-			//if (key == null) return;
-			onSelect?.(key, event);
-			parentOnSelect?.(key, event);
-		};
-
-		return (
-			<SelectableContext.Provider value={handleSelect}>
-				<NavContext.Provider
-					value={{
-						role, // used by NavLink to determine it's role
-						activeKey: makeEventKey(activeKey),
-						getControlledId: getControlledId || noop,
-						getControllerId: getControllerId || noop,
-					}}
-				>
-					<Component {...props} ref={ref} role={role} />
-				</NavContext.Provider>
-			</SelectableContext.Provider>
-		);
-	},
-);
+	);
 
 export default AbstractNav;

--- a/VocaDbWeb/Scripts/Bootstrap/safeFindDOMNode.ts
+++ b/VocaDbWeb/Scripts/Bootstrap/safeFindDOMNode.ts
@@ -5,6 +5,7 @@ export default function safeFindDOMNode(
 	componentOrElement: React.ComponentClass | Element | null | undefined,
 ): Element | Text | null {
 	if (componentOrElement && 'setState' in componentOrElement) {
+		// @ts-ignore
 		return ReactDOM.findDOMNode(componentOrElement);
 	}
 	return (componentOrElement ?? null) as Element | Text | null;

--- a/VocaDbWeb/Scripts/Components/KnockoutExtensions/EntryToolTip.tsx
+++ b/VocaDbWeb/Scripts/Components/KnockoutExtensions/EntryToolTip.tsx
@@ -147,7 +147,7 @@ interface EventToolTipProps {
 }
 
 export const EventToolTip = React.memo(
-	({ id, children, bold }: EventToolTipProps): React.ReactElement => {
+	({ id, children }: EventToolTipProps): React.ReactElement => {
 		const [show, setShow] = React.useState(false);
 
 		const [event, setEvent] = React.useState<ReleaseEventContract>();

--- a/VocaDbWeb/Scripts/Components/KnockoutExtensions/EntryToolTip.tsx
+++ b/VocaDbWeb/Scripts/Components/KnockoutExtensions/EntryToolTip.tsx
@@ -147,7 +147,7 @@ interface EventToolTipProps {
 }
 
 export const EventToolTip = React.memo(
-	({ id, children }: EventToolTipProps): React.ReactElement => {
+	({ id, children, bold }: EventToolTipProps): React.ReactElement => {
 		const [show, setShow] = React.useState(false);
 
 		const [event, setEvent] = React.useState<ReleaseEventContract>();

--- a/VocaDbWeb/Scripts/Components/Shared/Partials/Event/EventLink.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/Partials/Event/EventLink.tsx
@@ -7,11 +7,18 @@ import { Link } from 'react-router-dom';
 
 interface EventLinkBaseProps {
 	event: ReleaseEventContract;
+	bold?: boolean;
 }
 
-const EventLinkBase = ({ event }: EventLinkBaseProps): React.ReactElement => {
+const EventLinkBase = ({
+	event,
+	bold,
+}: EventLinkBaseProps): React.ReactElement => {
 	return (
-		<Link to={EntryUrlMapper.details(EntryType.ReleaseEvent, event.id)}>
+		<Link
+			style={bold ? { fontWeight: 700 } : undefined}
+			to={EntryUrlMapper.details(EntryType.ReleaseEvent, event.id)}
+		>
 			{event.name}
 		</Link>
 	);
@@ -20,15 +27,17 @@ const EventLinkBase = ({ event }: EventLinkBaseProps): React.ReactElement => {
 interface EventLinkProps {
 	event: ReleaseEventContract;
 	tooltip?: boolean;
+	bold?: boolean;
 }
 
 export const EventLink = ({
 	event,
 	tooltip,
+	bold,
 }: EventLinkProps): React.ReactElement => {
 	return tooltip ? (
 		<EventToolTip id={event.id}>
-			<EventLinkBase event={event} />
+			<EventLinkBase bold={bold} event={event} />
 		</EventToolTip>
 	) : (
 		<EventLinkBase event={event} />

--- a/VocaDbWeb/Scripts/Components/Shared/Partials/Knockout/ReleaseEventsEditView.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/Partials/Knockout/ReleaseEventsEditView.tsx
@@ -1,4 +1,5 @@
 import SafeAnchor from '@/Bootstrap/SafeAnchor';
+import { useLoginManager } from '@/LoginManagerContext';
 import { SongEditStore } from '@/Stores/Song/SongEditStore';
 import { observer } from 'mobx-react-lite';
 import { useTranslation } from 'react-i18next';
@@ -12,9 +13,9 @@ interface ReleaseEventsEditViewProps {
 export const ReleaseEventsEditView = observer(
 	({ songEditStore }: ReleaseEventsEditViewProps) => {
 		const { t } = useTranslation(['ViewRes', 'HelperRes']);
+		const loginManager = useLoginManager();
 
 		const releaseEvents = songEditStore.releaseEvents;
-		console.log(releaseEvents);
 
 		return (
 			<tbody>
@@ -28,13 +29,15 @@ export const ReleaseEventsEditView = observer(
 				))}
 
 				<tr>
-					<SafeAnchor
-						href="#"
-						className="textLink addLink"
-						onClick={songEditStore.addReleaseEvent}
-					>
-						{t('HelperRes:Helper.WebLinkNewRow')}
-					</SafeAnchor>
+					{(releaseEvents.length < 5 || loginManager.canApproveEntries) && (
+						<SafeAnchor
+							href="#"
+							className="textLink addLink"
+							onClick={songEditStore.addReleaseEvent}
+						>
+							{t('HelperRes:Helper.WebLinkNewRow')}
+						</SafeAnchor>
+					)}
 				</tr>
 			</tbody>
 		);

--- a/VocaDbWeb/Scripts/Components/Shared/Partials/Knockout/ReleaseEventsEditView.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/Partials/Knockout/ReleaseEventsEditView.tsx
@@ -1,5 +1,6 @@
 import SafeAnchor from '@/Bootstrap/SafeAnchor';
 import { useLoginManager } from '@/LoginManagerContext';
+import { AlbumEditStore } from '@/Stores/Album/AlbumEditStore';
 import { SongEditStore } from '@/Stores/Song/SongEditStore';
 import { observer } from 'mobx-react-lite';
 import { useTranslation } from 'react-i18next';
@@ -7,15 +8,15 @@ import { useTranslation } from 'react-i18next';
 import { ReleaseEventLockingAutoComplete } from './ReleaseEventLockingAutoComplete';
 
 interface ReleaseEventsEditViewProps {
-	songEditStore: SongEditStore;
+	editStore: SongEditStore | AlbumEditStore;
 }
 
 export const ReleaseEventsEditView = observer(
-	({ songEditStore }: ReleaseEventsEditViewProps) => {
+	({ editStore }: ReleaseEventsEditViewProps) => {
 		const { t } = useTranslation(['ViewRes', 'HelperRes']);
 		const loginManager = useLoginManager();
 
-		const releaseEvents = songEditStore.releaseEvents;
+		const releaseEvents = editStore.releaseEvents;
 
 		return (
 			<tbody>
@@ -33,7 +34,7 @@ export const ReleaseEventsEditView = observer(
 						<SafeAnchor
 							href="#"
 							className="textLink addLink"
-							onClick={songEditStore.addReleaseEvent}
+							onClick={editStore.addReleaseEvent}
 						>
 							{t('HelperRes:Helper.WebLinkNewRow')}
 						</SafeAnchor>

--- a/VocaDbWeb/Scripts/DataContracts/Album/AlbumDetailsForApi.ts
+++ b/VocaDbWeb/Scripts/DataContracts/Album/AlbumDetailsForApi.ts
@@ -108,6 +108,7 @@ export class AlbumDetailsForApi {
 	readonly ratingCount: number;
 	readonly releaseDate?: OptionalDateTimeContract;
 	readonly releaseEvent?: ReleaseEventContract;
+	readonly releaseEvents: ReleaseEventContract[] = [];
 	readonly reviewCount: number;
 	readonly status: EntryStatus;
 	readonly subject: ArtistForAlbumContract[];
@@ -184,6 +185,7 @@ export class AlbumDetailsForApi {
 		if (contract.originalRelease) {
 			this.catNum = contract.originalRelease.catNum;
 			this.releaseEvent = contract.originalRelease.releaseEvent;
+			this.releaseEvents = contract.originalRelease.releaseEvents;
 			this.releaseDate = contract.originalRelease.releaseDate;
 			this.fullReleaseDate =
 				this.releaseDate &&

--- a/VocaDbWeb/Scripts/DataContracts/Album/AlbumReleaseContract.ts
+++ b/VocaDbWeb/Scripts/DataContracts/Album/AlbumReleaseContract.ts
@@ -7,4 +7,6 @@ export interface AlbumReleaseContract {
 	releaseDate?: OptionalDateTimeContract;
 
 	releaseEvent?: ReleaseEventContract;
+
+	releaseEvents: ReleaseEventContract[];
 }

--- a/VocaDbWeb/Scripts/Pages/Album/AlbumBasicInfo.tsx
+++ b/VocaDbWeb/Scripts/Pages/Album/AlbumBasicInfo.tsx
@@ -419,11 +419,23 @@ const AlbumBasicInfo = observer(
 								</tr>
 							)}
 
-							{model.releaseEvent && (
+							{model.releaseEvents.length > 0 && (
 								<tr>
 									<td>{t('ViewRes.Album:Details.ReleaseEvent')}</td>
 									<td>
-										<EventLink event={model.releaseEvent} tooltip />
+										{model.releaseEvents
+											.slice()
+											.sort(
+												(a, b) =>
+													(a.date ? new Date(a.date).getTime() : Infinity) -
+													(b.date ? new Date(b.date).getTime() : Infinity),
+											)
+											.map((event, key) => (
+												<span key={key}>
+													{key !== 0 ? ', ' : ''}
+													<EventLink bold={key === 0} event={event} tooltip />
+												</span>
+											))}
 									</td>
 								</tr>
 							)}

--- a/VocaDbWeb/Scripts/Pages/Album/AlbumEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Album/AlbumEdit.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/Components/Shared/Partials/Knockout/DropdownList';
 import { EntryValidationMessage } from '@/Components/Shared/Partials/Knockout/EntryValidationMessage';
 import { ReleaseEventLockingAutoComplete } from '@/Components/Shared/Partials/Knockout/ReleaseEventLockingAutoComplete';
+import { ReleaseEventsEditView } from '@/Components/Shared/Partials/Knockout/ReleaseEventsEditView';
 import { WebLinksEditViewKnockout } from '@/Components/Shared/Partials/Knockout/WebLinksEditViewKnockout';
 import { ConcurrentEditWarning } from '@/Components/Shared/Partials/Shared/ConcurrentEditWarning';
 import { HelpLabel } from '@/Components/Shared/Partials/Shared/HelpLabel';
@@ -222,10 +223,7 @@ const BasicInfoTabContent = observer(
 					<label>{t('ViewRes.Album:Edit.BaReleaseEvent')}</label>
 				</div>
 				<div className="editor-field">
-					<ReleaseEventLockingAutoComplete
-						basicEntryLinkStore={albumEditStore.releaseEvent}
-						// TODO: createNewItem="Create new event '{0}'" /* LOC */
-					/>
+					<ReleaseEventsEditView editStore={albumEditStore} />
 				</div>
 
 				<table>
@@ -1148,10 +1146,12 @@ const AlbumEdit = (): React.ReactElement => {
 	const artistRoleNames = React.useMemo(
 		() =>
 			Object.fromEntries(
-				vdb.values.artistRoles.map((artistRole): [
-					string,
-					string | undefined,
-				] => [artistRole, t(`Resources:ArtistRoleNames.${artistRole}`)]),
+				vdb.values.artistRoles.map(
+					(artistRole): [string, string | undefined] => [
+						artistRole,
+						t(`Resources:ArtistRoleNames.${artistRole}`),
+					],
+				),
 			),
 		[vdb, t],
 	);

--- a/VocaDbWeb/Scripts/Pages/Song/SongBasicInfo.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongBasicInfo.tsx
@@ -637,17 +637,24 @@ const SongBasicInfo = observer(
 							<tr>
 								<td>{t('ViewRes.Song:Details.ReleaseEvent')}</td>
 								<td>
-									{model.releaseEvents.map((event, key) => (
-										<>
-											{key !== 0 ? ', ' : ''}
-											<EventLink
-												bold={key === 0}
-												event={event}
-												key={key}
-												tooltip
-											/>
-										</>
-									))}
+									{model.releaseEvents
+										.slice()
+										.sort(
+											(a, b) =>
+												(a.date ? new Date(a.date).getTime() : Infinity) -
+												(b.date ? new Date(b.date).getTime() : Infinity),
+										)
+										.map((event, key) => (
+											<>
+												{key !== 0 ? ', ' : ''}
+												<EventLink
+													bold={key === 0}
+													event={event}
+													key={key}
+													tooltip
+												/>
+											</>
+										))}
 								</td>
 							</tr>
 						)}

--- a/VocaDbWeb/Scripts/Pages/Song/SongBasicInfo.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongBasicInfo.tsx
@@ -645,15 +645,10 @@ const SongBasicInfo = observer(
 												(b.date ? new Date(b.date).getTime() : Infinity),
 										)
 										.map((event, key) => (
-											<>
+											<span key={key}>
 												{key !== 0 ? ', ' : ''}
-												<EventLink
-													bold={key === 0}
-													event={event}
-													key={key}
-													tooltip
-												/>
-											</>
+												<EventLink bold={key === 0} event={event} tooltip />
+											</span>
 										))}
 								</td>
 							</tr>

--- a/VocaDbWeb/Scripts/Pages/Song/SongBasicInfo.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongBasicInfo.tsx
@@ -640,7 +640,12 @@ const SongBasicInfo = observer(
 									{model.releaseEvents.map((event, key) => (
 										<>
 											{key !== 0 ? ', ' : ''}
-											<EventLink event={event} key={key} tooltip />
+											<EventLink
+												bold={key === 0}
+												event={event}
+												key={key}
+												tooltip
+											/>
 										</>
 									))}
 								</td>

--- a/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
@@ -305,7 +305,7 @@ const BasicInfoTabContent = observer(
 					<label>Release event{/* LOC */}</label>
 				</div>
 				<div className="editor-field">
-					<ReleaseEventsEditView songEditStore={songEditStore} />
+					<ReleaseEventsEditView editStore={songEditStore} />
 				</div>
 
 				<div className="editor-label">

--- a/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
@@ -429,7 +429,8 @@ const BasicInfoTabContent = observer(
 									</tr>
 								))}
 							</tbody>
-							{songEditStore.cultureCodes.items.length < 3 && (
+							{(songEditStore.cultureCodes.items.length < 3 ||
+								loginManager.canApproveEntries) && (
 								<SafeAnchor
 									href="#"
 									className="textLink addLink"


### PR DESCRIPTION
#1544 implemented multiple release events for songs. This PR adds the functionality to albums.

TODO
- [x] Migrate release events into separate table
- [x] Update mappings and business logic
- [x] Update tests
- [x] Update UI
- [ ] Write documentation