### PR TITLE
fix: Smaller release event fixes

### DIFF
--- a/VocaDbWeb/Scripts/DataContracts/Album/AlbumContract.ts
+++ b/VocaDbWeb/Scripts/DataContracts/Album/AlbumContract.ts
@@ -17,6 +17,7 @@ export interface AlbumContract
 	ratingCount: number;
 	releaseDate: OptionalDateTimeContract;
 	releaseEvent?: ReleaseEventContract;
+	releaseEvents: ReleaseEventContract[];
 	status: EntryStatus;
 	version: number;
 }

--- a/VocaDbWeb/Scripts/Pages/Search/Partials/AlbumSearchList.tsx
+++ b/VocaDbWeb/Scripts/Pages/Search/Partials/AlbumSearchList.tsx
@@ -196,19 +196,21 @@ const AlbumSearchList = observer(
 												album.releaseDate.day,
 											)}
 										</span>
-										{album.releaseEvent && (
-											<span>
-												<br />
-												<Link
-													to={EntryUrlMapper.details(
-														EntryType.ReleaseEvent,
-														album.releaseEvent.id,
-													)}
-												>
-													{album.releaseEvent.name}
-												</Link>
-											</span>
-										)}
+										{album.releaseEvents
+											.filter((_e, index) => index < 3)
+											.map((e, index) => (
+												<span key={index}>
+													{index === 0 ? <br /> : ', '}
+													<Link
+														to={EntryUrlMapper.details(
+															EntryType.ReleaseEvent,
+															e.id,
+														)}
+													>
+														{e.name}
+													</Link>
+												</span>
+											))}
 									</td>
 									<td style={{ width: '150px' }}>
 										<span title={`${album.ratingAverage}`}>

--- a/VocaDbWeb/Scripts/Stores/Album/AlbumEditStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Album/AlbumEditStore.ts
@@ -178,6 +178,10 @@ export class AlbumEditStore {
 			return store;
 		})
 
+		if (this.releaseEvents.length === 0) {
+			this.addReleaseEvent()
+		}
+
 		this.catalogNumber = contract.originalRelease.catNum;
 		this.defaultNameLanguage = contract.defaultNameLanguage;
 		this.description = new EnglishTranslatedStringEditStore(

--- a/VocaDbWeb/Scripts/Stores/Album/AlbumEditStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Album/AlbumEditStore.ts
@@ -303,9 +303,14 @@ export class AlbumEditStore {
 	}
 
 	@computed get eventDate(): Dayjs | undefined {
-		return this.releaseEvent.entry && this.releaseEvent.entry.date
-			? dayjs(this.releaseEvent.entry.date)
-			: undefined;
+		return this.releaseEvents
+			.map(e => e.entry)
+			.filter(e => e !== undefined)
+			.sort(
+				(a, b) =>
+					(a!.date ? new Date(a!.date).getTime() : Infinity) -
+					(b!.date ? new Date(b!.date).getTime() : Infinity),
+			).map(e => dayjs(e!.date))[0]
 	}
 
 	@computed get releaseDate(): Dayjs | undefined {

--- a/VocaDbWeb/Scripts/Stores/Song/SongEditStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Song/SongEditStore.ts
@@ -123,6 +123,10 @@ export class SongEditStore {
 			return store;
 		})
 
+		if (this.releaseEvents.length === 0) {
+			this.addReleaseEvent()
+		}
+
 		this.albumEventId = contract.albumEventId;
 		this.albumReleaseDate = contract.albumReleaseDate
 			? dayjs(contract.albumReleaseDate)


### PR DESCRIPTION
- [x] Suggest the earliest release event date as release date for albums
- [x] Always show one release event field for song and album edit pages
- [x] Show release events on album search page