### PR TITLE
fix: Unify comment api

### DIFF
--- a/VocaDbModel/Database/Queries/CommentQueries.cs
+++ b/VocaDbModel/Database/Queries/CommentQueries.cs
@@ -4,10 +4,15 @@ using VocaDb.Model.DataContracts;
 using VocaDb.Model.DataContracts.Api;
 using VocaDb.Model.DataContracts.Users;
 using VocaDb.Model.Domain;
+using VocaDb.Model.Domain.Albums;
+using VocaDb.Model.Domain.Artists;
 using VocaDb.Model.Domain.Comments;
+using VocaDb.Model.Domain.Discussions;
 using VocaDb.Model.Domain.Globalization;
 using VocaDb.Model.Domain.ReleaseEvents;
 using VocaDb.Model.Domain.Security;
+using VocaDb.Model.Domain.Songs;
+using VocaDb.Model.Domain.Users;
 using VocaDb.Model.Service;
 using VocaDb.Model.Service.Queries;
 using VocaDb.Model.Service.QueryableExtensions;
@@ -42,6 +47,11 @@ public class CommentQueries
 	private ICommentQueries GetComments(IDatabaseContext ctx, EntryType entryType) => entryType switch
 	{
 		EntryType.ReleaseEvent => new CommentQueries<ReleaseEventComment, ReleaseEvent>(ctx, _userContext, _userIconFactory, _entryLinkFactory),
+		EntryType.Song => new CommentQueries<SongComment, Song>(ctx, _userContext, _userIconFactory, _entryLinkFactory),
+		EntryType.Album => new CommentQueries<AlbumComment, Album>(ctx, _userContext, _userIconFactory, _entryLinkFactory),
+		EntryType.Artist => new CommentQueries<ArtistComment, Artist>(ctx, _userContext, _userIconFactory, _entryLinkFactory),
+		EntryType.DiscussionTopic => new CommentQueries<DiscussionComment, DiscussionTopic>(ctx, _userContext, _userIconFactory, _entryLinkFactory),
+		EntryType.User => new CommentQueries<UserComment, User>(ctx, _userContext, _userIconFactory, _entryLinkFactory),
 		_ => throw new ArgumentException($"Unsupported entry type: {entryType}", nameof(entryType)),
 	};
 

--- a/VocaDbWeb/Helpers/OriginValidationFilter.cs
+++ b/VocaDbWeb/Helpers/OriginValidationFilter.cs
@@ -7,10 +7,10 @@ public class OriginValidationFilter : IActionFilter
 	{
 		var requestOrigin = context.HttpContext.Request.Headers["Origin"].First();
 		// TODO: Make this list configurable
-		var allowedOrigins = new[] { "https://vocadb.net", "https://touhoudb.com", "https://utaitedb.net", "http://localhost:56401", "https://vocadb.vercel.app", "https://beta.vocadb.net", "http://localhost:5173" };
+		var allowedOrigins = new[] { "https://vocadb.net", "https://touhoudb.com", "https://utaitedb.net", "https://vocadb.vercel.app", "https://beta.vocadb.net" };
 
 		// TODO: Don't allow a null origin (Breaking Change)
-		if (requestOrigin != null && !allowedOrigins.Contains(requestOrigin))
+		if (requestOrigin != null && !allowedOrigins.Contains(requestOrigin) && !requestOrigin.StartsWith("http://localhost"))
 		{
 			context.Result = new BadRequestResult();
 		}


### PR DESCRIPTION
Fixes #1311. Merges all of the current comment API endpoints. We will still keep the old endpoints for now to prevent breaking changes.