### PR TITLE
Allow original songs to be derived from another song

### DIFF
--- a/VocaDbModel/Domain/Songs/Song.cs
+++ b/VocaDbModel/Domain/Songs/Song.cs
@@ -227,7 +227,7 @@ public class Song :
 	/// This method also tests that the song type isn't "Original", because original songs aren't supposed to have parent songs.
 	/// </summary>
 	[MemberNotNullWhen(true, nameof(OriginalVersion))]
-	public virtual bool HasOriginalVersion => SongType != SongType.Original && OriginalVersion != null;
+	public virtual bool HasOriginalVersion => OriginalVersion != null;
 
 	public virtual IList<SongHit> Hits
 	{

--- a/VocaDbWeb/Models/SongModels.cs
+++ b/VocaDbWeb/Models/SongModels.cs
@@ -34,7 +34,7 @@ public class SongDetails
 		Contract = contract;
 		AdditionalNames = contract.AdditionalNames;
 		Albums = contract.Albums;
-		AlternateVersions = contract.AlternateVersions.Where(a => a.SongType != SongType.Original).ToArray();
+		AlternateVersions = contract.AlternateVersions;
 		ArtistString = contract.ArtistString;
 		BrowsedAlbumId = contract.Album?.Id;
 		CanEdit = EntryPermissionManager.CanEdit(userContext, contract.Song);
@@ -58,7 +58,7 @@ public class SongDetails
 		Name = contract.Song.Name;
 		NicoId = contract.Song.NicoId;
 		Notes = contract.Notes;
-		OriginalVersion = (contract.Song.SongType != SongType.Original ? contract.OriginalVersion : null);
+		OriginalVersion = contract.OriginalVersion;
 		Pools = contract.Pools;
 		PublishDate = contract.Song.PublishDate;
 		RatingScore = contract.Song.RatingScore;

--- a/VocaDbWeb/New/types/DataContracts/Song/SongDetailsForApi.ts
+++ b/VocaDbWeb/New/types/DataContracts/Song/SongDetailsForApi.ts
@@ -76,9 +76,7 @@ export class SongDetailsForApi {
 	constructor(readonly contract: SongDetailsContract, primaryPV: PVContract | undefined) {
 		this.additionalNames = contract.additionalNames;
 		this.albums = contract.albums;
-		this.alternateVersions = contract.alternateVersions.filter(
-			(a) => a.songType !== SongType.Original
-		);
+		this.alternateVersions = contract.alternateVersions;
 		this.artistString = contract.artistString;
 		this.browsedAlbumId = contract.album?.id;
 		this.canEditPersonalDescription = contract.canEditPersonalDescription;
@@ -101,10 +99,7 @@ export class SongDetailsForApi {
 		this.minMilliBpm = contract.minMilliBpm;
 		this.name = contract.song.name;
 		this.notes = contract.notes;
-
-		this.originalVersion =
-			contract.song.songType !== SongType.Original ? contract.originalVersion : undefined;
-
+		this.originalVersion = contract.originalVersion;
 		this.personalDescriptionAuthor = contract.personalDescriptionAuthor;
 		this.personalDescriptionText = contract.personalDescriptionText;
 		this.pools = contract.pools;

--- a/VocaDbWeb/Scripts/DataContracts/Song/SongDetailsForApi.ts
+++ b/VocaDbWeb/Scripts/DataContracts/Song/SongDetailsForApi.ts
@@ -80,9 +80,7 @@ export class SongDetailsForApi {
 	) {
 		this.additionalNames = contract.additionalNames;
 		this.albums = contract.albums;
-		this.alternateVersions = contract.alternateVersions.filter(
-			(a) => a.songType !== SongType.Original,
-		);
+		this.alternateVersions = contract.alternateVersions;
 		this.artistString = contract.artistString;
 		this.browsedAlbumId = contract.album?.id;
 		this.canEditPersonalDescription = contract.canEditPersonalDescription;
@@ -105,12 +103,7 @@ export class SongDetailsForApi {
 		this.minMilliBpm = contract.minMilliBpm;
 		this.name = contract.song.name;
 		this.notes = contract.notes;
-
-		this.originalVersion =
-			contract.song.songType !== SongType.Original
-				? contract.originalVersion
-				: undefined;
-
+		this.originalVersion = contract.originalVersion;
 		this.personalDescriptionAuthor = contract.personalDescriptionAuthor;
 		this.personalDescriptionText = contract.personalDescriptionText;
 		this.pools = contract.pools;

--- a/VocaDbWeb/Scripts/Stores/Song/SongCreateStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Song/SongCreateStore.ts
@@ -78,6 +78,8 @@ export class SongCreateStore {
 	}
 
 	@computed get canHaveOriginalVersion(): boolean {
+		// Having a original/base version for an original song is uncommon.
+		// Hide the base version selector as that's more suited for this simplified interface.
 		return this.songType !== SongType.Original;
 	}
 

--- a/VocaDbWeb/Scripts/Stores/Song/SongDetailsStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Song/SongDetailsStore.ts
@@ -308,7 +308,7 @@ export class SongDetailsStore {
 
 		this.tagUsages = new TagListStore(data.tagUsages);
 
-		if (data.songType !== SongType.Original && !this.originalVersion.entry) {
+		if (!this.originalVersion.entry) {
 			this.getOriginal(data.linkedPages);
 		}
 	}

--- a/VocaDbWeb/Scripts/Stores/Song/SongEditStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Song/SongEditStore.ts
@@ -185,7 +185,7 @@ export class SongEditStore {
 	}
 
 	@computed get canHaveOriginalVersion(): boolean {
-		return this.songType !== SongType.Original;
+		return true;
 	}
 
 	@computed get showInstrumentalNote(): boolean {


### PR DESCRIPTION
- First part of the solution to #1585

As it turns out, original/base versions of original songs can already be added to the database, just that there's a bunch of special casing to try to hide that fact from the frontend and the API.

This PR just removes the special cases, allowing:
- original song pages to show their original/base versions under "Original version" (including API)
- base song pages to show the original song under "Alternate versions"

**Things that are currently missing from this PR:**
- UX considerations for the text shown, as having an original version of an original song is a bit cumbersome

# Breaking changes

## Original songs that have an original version entered in the database will show that in the UI

People could accidentally enter in an original version (and not realise it, as it's hidden). Those entries should be removed/fixed before this PR makes it in.

I'd like to see which songs are affected. In the spirit of not DoS-ing VocaDB, this is best queried directly from the database:
```sql
SELECT Id, EnglishName, ArtistString, OriginalVersion FROM Songs
WHERE SongType = 'Original' AND OriginalVersion IS NOT NULL;
GO
```

# Behaviour on current version of live website

You can already add an original version to an original song on the _live website_:

1. On the Edit page, change the song type to not be Original song
2. Select the desired song to be the Original version
3. Change song type back to Original song (while the GUI is invisible, the original version remains selected)
4. Save changes

You can see a song changed this way in https://vocadb.net/Song/ViewVersion/1714212.
But it won't show on the [main song page](https://vocadb.net/S/201986).

![image](https://github.com/VocaDB/vocadb/assets/16479013/445ac62a-2b7a-4abf-9179-ca804135f6fc)

Note the absence of `originalVersionId` in the [API request for the original song](https://vocadb.net/api/songs/201986)

![image](https://github.com/VocaDB/vocadb/assets/16479013/266697de-600e-4c41-93c8-80f67baa9e7b)

and the inclusion of the original song in the [base's derived songs](https://vocadb.net/api/songs/201987/derived).

![image](https://github.com/VocaDB/vocadb/assets/16479013/5d7e9224-e09e-4acc-9c51-c342028ebd81)
