### PR TITLE
fix: Remove tags from "anything" search results if a tag filter is used

### DIFF
--- a/VocaDbModel/Database/Queries/EntryQueries.cs
+++ b/VocaDbModel/Database/Queries/EntryQueries.cs
@@ -103,13 +103,16 @@ public class EntryQueries : QueriesBase<IAlbumRepository, Album>
 				.SelectEntryBase(lang, EntryType.ReleaseEvent)
 				.ToArray() : null;
 
-			var tagQuery = searchTags ? ctx.OfType<Tag>().Query()
+   			// We don't want to search for tags, if the user has selected a tag filter
+			var hasTagFilter = tagIds != null && tagIds.Length > 0;
+
+			var tagQuery = searchTags && !hasTagFilter ? ctx.OfType<Tag>().Query()
 				.WhereEntryTypeIsIncluded(entryTypes, EntryType.Tag)
 				.WhereNotDeleted()
 				.WhereHasName(textQuery)
 				.WhereStatusIs(status) : null;
 
-			var tagNames = searchTags ? tagQuery!
+			var tagNames = searchTags && !hasTagFilter ? tagQuery!
 				.OrderBy(sort, lang)
 				.Take(start + maxResults)
 				.SelectEntryBase(lang, EntryType.Tag)
@@ -184,7 +187,7 @@ public class EntryQueries : QueriesBase<IAlbumRepository, Album>
 					(songNames.Length >= maxResults ? songQuery.Count() : songNames.Length);
 
 				var tagCount =
-					searchTags ? (tagNames!.Length >= maxResults ? tagQuery!.Count() : tagNames.Length) : 0;
+					searchTags && !hasTagFilter ? (tagNames!.Length >= maxResults ? tagQuery!.Count() : tagNames.Length) : 0;
 
 				var eventCount =
 					searchEvents ? (eventNames!.Length >= maxResults ? eventQuery!.Count() : eventNames.Length) : 0;


### PR DESCRIPTION
Fixes a bug where all tags were returned if a user had selected a tag filter ([example](https://vocadb.net/Search?tagId=4997)).