### PR TITLE
chores: Update language options

### DIFF
--- a/VocaDbWeb/Scripts/Components/extendedUserLanguageCultures.ts
+++ b/VocaDbWeb/Scripts/Components/extendedUserLanguageCultures.ts
@@ -331,6 +331,13 @@ const rawLangs: RawLangs = [
 		},
 	],
 	[
+		'hnm',
+		{
+			languages: ['Hainanese'],
+			nativeName: '海南話'
+		}
+	],
+	[
 		'hak',
 		{
 			languages: ['Hakka Chinese', 'Keyu', 'Kejiahua', 'Hak-k\u00e2-fa'],
@@ -364,6 +371,9 @@ const rawLangs: RawLangs = [
 			languages: ['Hindi'],
 			nativeName: 'हिंदी',
 		},
+	],
+	[
+		'hbl', { languages: ['Hokkien'], nativeName: '闽南语' }
 	],
 	[
 		'hu',
@@ -669,6 +679,13 @@ const rawLangs: RawLangs = [
 		},
 	],
 	[
+		'qsb',
+		{
+			languages: ['Sambahsa'],
+			nativeName: 'Sambahsa-Mundialect'
+		}
+	],
+	[
 		'qsa',
 		{
 			languages: ['Sami', 'Sámi', 'Saami', 'Northern Sami', 'Southern Sami'],
@@ -791,6 +808,13 @@ const rawLangs: RawLangs = [
 			languages: ['Telugu'],
 			nativeName: 'తెలుగు',
 		},
+	],
+	[
+		'tws',
+		{
+			languages: ['Teochew'],
+			nativeName: '潮州話'
+		}
 	],
 	[
 		'th',

--- a/VocaDbWeb/Scripts/Components/extendedUserLanguageCultures.ts
+++ b/VocaDbWeb/Scripts/Components/extendedUserLanguageCultures.ts
@@ -707,6 +707,13 @@ const rawLangs: RawLangs = [
 		},
 	],
 	[
+		'sr',
+		{
+			languages: ['Serbian'],
+			nativeName: 'српски језик'
+		}
+	],
+	[
 		'snd',
 		{
 			languages: ['Sindhi'],

--- a/VocaDbWeb/Scripts/Components/extendedUserLanguageCultures.ts
+++ b/VocaDbWeb/Scripts/Components/extendedUserLanguageCultures.ts
@@ -121,8 +121,8 @@ const rawLangs: RawLangs = [
 		'bnn',
 		{
 			languages: ['Bunun'],
-			nativeName: 'Bunun'
-		}
+			nativeName: 'Bunun',
+		},
 	],
 	[
 		'my',
@@ -341,8 +341,8 @@ const rawLangs: RawLangs = [
 		'hnm',
 		{
 			languages: ['Hainanese'],
-			nativeName: '海南話'
-		}
+			nativeName: '海南話',
+		},
 	],
 	[
 		'hak',
@@ -355,8 +355,8 @@ const rawLangs: RawLangs = [
 		'hni',
 		{
 			languages: ['Hani'],
-			nativeName: 'Haqniqdoq'
-		}
+			nativeName: 'Haqniqdoq',
+		},
 	],
 	[
 		'ha',
@@ -390,12 +390,10 @@ const rawLangs: RawLangs = [
 		'hmn',
 		{
 			languages: ['Hmong', 'Mong'],
-			nativeName: '𖬌𖬣𖬵'
-		}
+			nativeName: '𖬌𖬣𖬵',
+		},
 	],
-	[
-		'hbl', { languages: ['Hokkien'], nativeName: '闽南语' }
-	],
+	['hbl', { languages: ['Hokkien'], nativeName: '闽南语' }],
 	[
 		'hu',
 		{
@@ -468,8 +466,8 @@ const rawLangs: RawLangs = [
 		'doc',
 		{
 			languages: ['Kam', 'Gam', 'Dong'],
-			nativeName: 'Gaeml'
-		}
+			nativeName: 'Gaeml',
+		},
 	],
 	[
 		'kn',
@@ -552,8 +550,8 @@ const rawLangs: RawLangs = [
 		'mnc',
 		{
 			languages: ['Manchu'],
-			nativeName: 'ᠮᠠᠨᠵᡠ ᡤᡳᠰᡠᠨ'
-		}
+			nativeName: 'ᠮᠠᠨᠵᡠ ᡤᡳᠰᡠᠨ',
+		},
 	],
 	[
 		'cmn',
@@ -587,8 +585,8 @@ const rawLangs: RawLangs = [
 		'okm',
 		{
 			languages: ['Middle Korean'],
-			nativeName: '중세 한국어'
-		}
+			nativeName: '중세 한국어',
+		},
 	],
 	[
 		'arb',
@@ -629,8 +627,8 @@ const rawLangs: RawLangs = [
 		'ii',
 		{
 			languages: ['Nuosu', 'Nosu'],
-			nativeName: 'ꆈꌠꉙ'
-		}
+			nativeName: 'ꆈꌠꉙ',
+		},
 	],
 	[
 		'ori',
@@ -688,7 +686,13 @@ const rawLangs: RawLangs = [
 			nativeName: 'ਪੰਜਾਬੀ',
 		},
 	],
-	['cpx', { languages: ['Pu-Xian', 'Pu-Xian Min', 'Xinghua', 'Henghwa'], nativeName: '莆仙語' }],
+	[
+		'cpx',
+		{
+			languages: ['Pu-Xian', 'Pu-Xian Min', 'Xinghua', 'Henghwa'],
+			nativeName: '莆仙語',
+		},
+	],
 	[
 		'que',
 		{
@@ -700,8 +704,8 @@ const rawLangs: RawLangs = [
 		'cng',
 		{
 			languages: ['Qiang', 'Rma', 'Rme'],
-			nativeName: '尔玛'
-		}
+			nativeName: '尔玛',
+		},
 	],
 	[
 		'ro',
@@ -739,8 +743,8 @@ const rawLangs: RawLangs = [
 		'qsb',
 		{
 			languages: ['Sambahsa'],
-			nativeName: 'Sambahsa-Mundialect'
-		}
+			nativeName: 'Sambahsa-Mundialect',
+		},
 	],
 	[
 		'qsa',
@@ -767,8 +771,8 @@ const rawLangs: RawLangs = [
 		'sr',
 		{
 			languages: ['Serbian'],
-			nativeName: 'српски језик'
-		}
+			nativeName: 'српски језик',
+		},
 	],
 	[
 		'snd',
@@ -878,8 +882,8 @@ const rawLangs: RawLangs = [
 		'tws',
 		{
 			languages: ['Teochew'],
-			nativeName: '潮州話'
-		}
+			nativeName: '潮州話',
+		},
 	],
 	[
 		'th',
@@ -906,8 +910,8 @@ const rawLangs: RawLangs = [
 		'tji',
 		{
 			languages: ['Tujia'],
-			nativeName: 'Bifzivsar'
-		}
+			nativeName: 'Bifzivsar',
+		},
 	],
 	[
 		'tr',
@@ -934,8 +938,8 @@ const rawLangs: RawLangs = [
 		'ug',
 		{
 			languages: ['Uyghur', 'Uighur', ' Eastern Turki'],
-			nativeName: 'ئۇيغۇرچە'
-		}
+			nativeName: 'ئۇيغۇرچە',
+		},
 	],
 	[
 		'vi',
@@ -983,8 +987,8 @@ const rawLangs: RawLangs = [
 		'za',
 		{
 			languages: ['Zhuang', 'Chuang'],
-			nativeName: 'Vahcuengh'
-		}
+			nativeName: 'Vahcuengh',
+		},
 	],
 	[
 		'zu',

--- a/VocaDbWeb/Scripts/Components/extendedUserLanguageCultures.ts
+++ b/VocaDbWeb/Scripts/Components/extendedUserLanguageCultures.ts
@@ -118,6 +118,13 @@ const rawLangs: RawLangs = [
 		},
 	],
 	[
+		'bnn',
+		{
+			languages: ['Bunun'],
+			nativeName: 'Bunun'
+		}
+	],
+	[
 		'my',
 		{
 			languages: ['Burmese', 'Myanmar language'],
@@ -345,6 +352,13 @@ const rawLangs: RawLangs = [
 		},
 	],
 	[
+		'hni',
+		{
+			languages: ['Hani'],
+			nativeName: 'Haqniqdoq'
+		}
+	],
+	[
 		'ha',
 		{
 			languages: ['Hausa'],
@@ -371,6 +385,13 @@ const rawLangs: RawLangs = [
 			languages: ['Hindi'],
 			nativeName: 'हिंदी',
 		},
+	],
+	[
+		'hmn',
+		{
+			languages: ['Hmong', 'Mong'],
+			nativeName: '𖬌𖬣𖬵'
+		}
 	],
 	[
 		'hbl', { languages: ['Hokkien'], nativeName: '闽南语' }
@@ -442,6 +463,13 @@ const rawLangs: RawLangs = [
 			languages: ['Jin Chinese'],
 			nativeName: '晉語',
 		},
+	],
+	[
+		'doc',
+		{
+			languages: ['Kam', 'Gam', 'Dong'],
+			nativeName: 'Gaeml'
+		}
 	],
 	[
 		'kn',
@@ -521,6 +549,13 @@ const rawLangs: RawLangs = [
 		},
 	],
 	[
+		'mnc',
+		{
+			languages: ['Manchu'],
+			nativeName: 'ᠮᠠᠨᠵᡠ ᡤᡳᠰᡠᠨ'
+		}
+	],
+	[
 		'cmn',
 		{
 			languages: ['Mandarin Chinese', 'Northern Chinese'],
@@ -547,6 +582,13 @@ const rawLangs: RawLangs = [
 			languages: ['Middle Chinese', 'Ancient Chinese', 'Qieyun system'],
 			nativeName: '中古漢語',
 		},
+	],
+	[
+		'okm',
+		{
+			languages: ['Middle Korean'],
+			nativeName: '중세 한국어'
+		}
 	],
 	[
 		'arb',
@@ -582,6 +624,13 @@ const rawLangs: RawLangs = [
 			languages: ['Norwegian'],
 			nativeName: 'norsk',
 		},
+	],
+	[
+		'ii',
+		{
+			languages: ['Nuosu', 'Nosu'],
+			nativeName: 'ꆈꌠꉙ'
+		}
 	],
 	[
 		'ori',
@@ -639,12 +688,20 @@ const rawLangs: RawLangs = [
 			nativeName: 'ਪੰਜਾਬੀ',
 		},
 	],
+	['cpx', { languages: ['Pu-Xian', 'Pu-Xian Min', 'Xinghua', 'Henghwa'], nativeName: '莆仙語' }],
 	[
 		'que',
 		{
 			languages: ['Quechua', 'Runasimi', 'Kichwa'],
 			nativeName: 'Runasimi',
 		},
+	],
+	[
+		'cng',
+		{
+			languages: ['Qiang', 'Rma', 'Rme'],
+			nativeName: '尔玛'
+		}
 	],
 	[
 		'ro',
@@ -809,6 +866,7 @@ const rawLangs: RawLangs = [
 			nativeName: 'தமிழ்',
 		},
 	],
+	['txg', { languages: ['Tangut'], nativeName: '𗼇𗟲' }],
 	[
 		'te',
 		{
@@ -845,6 +903,13 @@ const rawLangs: RawLangs = [
 		},
 	],
 	[
+		'tji',
+		{
+			languages: ['Tujia'],
+			nativeName: 'Bifzivsar'
+		}
+	],
+	[
 		'tr',
 		{
 			languages: ['Turkish'],
@@ -864,6 +929,13 @@ const rawLangs: RawLangs = [
 			languages: ['Urdu'],
 			nativeName: 'اردو',
 		},
+	],
+	[
+		'ug',
+		{
+			languages: ['Uyghur', 'Uighur', ' Eastern Turki'],
+			nativeName: 'ئۇيغۇرچە'
+		}
 	],
 	[
 		'vi',
@@ -906,6 +978,13 @@ const rawLangs: RawLangs = [
 			languages: ['Yoruba'],
 			nativeName: 'Èdè Yorùbá',
 		},
+	],
+	[
+		'za',
+		{
+			languages: ['Zhuang', 'Chuang'],
+			nativeName: 'Vahcuengh'
+		}
 	],
 	[
 		'zu',

--- a/VocaDbWeb/Scripts/Components/userLanguageCultureFamilies.ts
+++ b/VocaDbWeb/Scripts/Components/userLanguageCultureFamilies.ts
@@ -11,6 +11,11 @@ export const userLanguageCultureFamilies = {
 		'och',
 		'ltc',
 		'cdo',
+		'hbl',
+		'tws',
+		'hnm',
+		'cpx'
 	],
 	ja: ['ain', 'ojp', 'qry'],
+	ko: ['okm']
 };


### PR DESCRIPTION
This PR includes the following changes to the language list:

- Added Serbian
- Added Sambahsa
- Added Hokkien, Teochew and Hainanese (preserved Southern Min)
- Added Zhuang, Tangut, Middle Korean, Nuosu, Tujia, Manchu, Hmong, Kam, Pu-Xian, Hani, Qiang, Bunun and Uyghur
- Added Hokkien, Teochew, Hainanese and Pu-Xian to the Chinese language family
- Created a Korean language family and added Middle Korean

The current language list can be found in the [online spreadsheet](https://docs.google.com/spreadsheets/d/1DQPeAn3echjZMgJBdXpFkeEsNQ6nN0csehiCLy_ApZM/edit#gid=0).