### PR TITLE
feat: Implement edit rate limit

### DIFF
--- a/VocaDbWeb/Controllers/Api/AlbumApiController.cs
+++ b/VocaDbWeb/Controllers/Api/AlbumApiController.cs
@@ -47,13 +47,15 @@ public class AlbumApiController : ApiController
 	private readonly AlbumQueries _queries;
 	private readonly AlbumService _service;
 	private readonly IUserPermissionContext _permissionContext;
+	private readonly EditRateLimitService _rateLimitService;
 
 	public AlbumApiController(
 		AlbumQueries queries,
 		AlbumService service,
 		OtherService otherService,
 		IAggregatedEntryImageUrlFactory thumbPersister,
-		IUserPermissionContext permissionContext
+		IUserPermissionContext permissionContext,
+		EditRateLimitService rateLimitService
 	)
 	{
 		_queries = queries;
@@ -61,6 +63,7 @@ public class AlbumApiController : ApiController
 		_otherService = otherService;
 		_thumbPersister = thumbPersister;
 		_permissionContext = permissionContext;
+		_rateLimitService = rateLimitService;
 	}
 
 	/// <summary>
@@ -423,6 +426,8 @@ public class AlbumApiController : ApiController
 		[ModelBinder(BinderType = typeof(JsonModelBinder))] AlbumForEditForApiContract contract
 	)
 	{
+		_rateLimitService.RegisterEdit(_permissionContext);
+		
 		// Unable to continue if viewmodel is null because we need the ID at least
 		if (contract is null)
 		{

--- a/VocaDbWeb/Controllers/Api/ArtistApiController.cs
+++ b/VocaDbWeb/Controllers/Api/ArtistApiController.cs
@@ -45,13 +45,15 @@ public class ArtistApiController : ApiController
 	private readonly ArtistService _service;
 	private readonly IAggregatedEntryImageUrlFactory _thumbPersister;
 	private readonly IUserPermissionContext _permissionContext;
+	private readonly EditRateLimitService _rateLimitService;
 
 	public ArtistApiController(
 		ArtistQueries queries,
 		ArtistService service,
 		IAggregatedEntryImageUrlFactory thumbPersister,
 		ObjectCache cache,
-		IUserPermissionContext permissionContext
+		IUserPermissionContext permissionContext,
+		EditRateLimitService rateLimitService
 	)
 	{
 		_queries = queries;
@@ -59,6 +61,7 @@ public class ArtistApiController : ApiController
 		_thumbPersister = thumbPersister;
 		_cache = cache;
 		_permissionContext = permissionContext;
+		_rateLimitService = rateLimitService;
 	}
 
 	private ArtistForApiContract GetArtist(
@@ -332,6 +335,8 @@ public class ArtistApiController : ApiController
 		[ModelBinder(BinderType = typeof(JsonModelBinder))] ArtistForEditForApiContract contract
 	)
 	{
+		_rateLimitService.RegisterEdit(_permissionContext);
+		
 		// Unable to continue if viewmodel is null because we need the ID at least
 		if (contract is null)
 		{

--- a/VocaDbWeb/Controllers/Api/ReleaseEventApiController.cs
+++ b/VocaDbWeb/Controllers/Api/ReleaseEventApiController.cs
@@ -41,16 +41,19 @@ public class ReleaseEventApiController : ApiController
 	private readonly EventQueries _queries;
 	private readonly IAggregatedEntryImageUrlFactory _thumbPersister;
 	private readonly IUserPermissionContext _permissionContext;
+	private readonly EditRateLimitService _rateLimitService;
 
 	public ReleaseEventApiController(
 		EventQueries queries,
 		IAggregatedEntryImageUrlFactory thumbPersister,
-		IUserPermissionContext permissionContext
+		IUserPermissionContext permissionContext,
+		EditRateLimitService rateLimitService
 	)
 	{
 		_queries = queries;
 		_thumbPersister = thumbPersister;
 		_permissionContext = permissionContext;
+		_rateLimitService = rateLimitService;
 	}
 
 	/// <summary>
@@ -260,6 +263,8 @@ public class ReleaseEventApiController : ApiController
 		IFormFile? pictureUpload
 	)
 	{
+		_rateLimitService.RegisterEdit(_permissionContext);
+		
 		// Either series or name must be specified. If series is specified, name is generated automatically.
 		if (contract.Series.IsNullOrDefault() || contract.CustomName)
 		{

--- a/VocaDbWeb/Controllers/Api/SongApiController.cs
+++ b/VocaDbWeb/Controllers/Api/SongApiController.cs
@@ -54,6 +54,7 @@ public class SongApiController : ApiController
 	private readonly UserService _userService;
 	private readonly IUserPermissionContext _userPermissionContext;
 	private readonly PVHelper _pvHelper;
+	private readonly EditRateLimitService _rateLimitService;
 
 	/// <summary>
 	/// Initializes controller.
@@ -66,7 +67,8 @@ public class SongApiController : ApiController
 		IUserPermissionContext userPermissionContext,
 		UserService userService,
 		OtherService otherService,
-		PVHelper pvHelper
+		PVHelper pvHelper,
+		EditRateLimitService rateLimitService
 	)
 	{
 		_service = service;
@@ -77,6 +79,7 @@ public class SongApiController : ApiController
 		_userPermissionContext = userPermissionContext;
 		_otherService = otherService;
 		_pvHelper = pvHelper;
+		_rateLimitService = rateLimitService;
 	}
 
 	/// <summary>
@@ -637,6 +640,8 @@ public class SongApiController : ApiController
 		[ModelBinder(BinderType = typeof(JsonModelBinder))] SongForEditForApiContract contract
 	)
 	{
+		_rateLimitService.RegisterEdit(_userPermissionContext);
+		
 		// Unable to continue if viewmodel is null because we need the ID at least
 		if (contract is null)
 		{

--- a/VocaDbWeb/Controllers/Api/TagApiController.cs
+++ b/VocaDbWeb/Controllers/Api/TagApiController.cs
@@ -42,16 +42,19 @@ public class TagApiController : ApiController
 	private readonly TagQueries _queries;
 	private readonly IAggregatedEntryImageUrlFactory _thumbPersister;
 	private readonly IUserPermissionContext _permissionContext;
+	private readonly EditRateLimitService _rateLimitService;
 
 	public TagApiController(
 		TagQueries queries,
 		IAggregatedEntryImageUrlFactory thumbPersister,
-		IUserPermissionContext permissionContext
+		IUserPermissionContext permissionContext,
+		EditRateLimitService rateLimitService
 	)
 	{
 		_queries = queries;
 		_thumbPersister = thumbPersister;
 		_permissionContext = permissionContext;
+		_rateLimitService = rateLimitService;
 	}
 
 	/// <summary>
@@ -397,6 +400,8 @@ public class TagApiController : ApiController
 		[ModelBinder(BinderType = typeof(JsonModelBinder))] TagForEditForApiContract contract
 	)
 	{
+		_rateLimitService.RegisterEdit(_permissionContext);
+		
 		var coverPicUpload = Request.Form.Files["thumbPicUpload"];
 		UploadedFileContract? uploadedPicture = null;
 		if (coverPicUpload is not null && coverPicUpload.Length > 0)

--- a/VocaDbWeb/Helpers/EditRateLimitService.cs
+++ b/VocaDbWeb/Helpers/EditRateLimitService.cs
@@ -1,0 +1,57 @@
+using VocaDb.Model.Domain.Security;
+using VocaDb.Model.Domain.Users;
+
+namespace VocaDb.Web.Helpers;
+
+public class EditRateLimitService 
+{
+	// Initialize request tracking
+	private readonly Dictionary<int, List<DateTime>> _userEndpointRequests = new();
+
+	public bool IsAllowed(IUserPermissionContext permissionContext)
+	{
+		var userId = permissionContext.LoggedUserId;
+		if (!_userEndpointRequests.ContainsKey(userId))
+		{
+			_userEndpointRequests[userId] = new List<DateTime>();
+		}
+
+		var requestTimes = _userEndpointRequests[userId];
+
+		// Remove requests older than an hour
+		requestTimes.RemoveAll(time => time < DateTime.Now.AddHours(-1));
+
+		var requestLimit = permissionContext.UserGroupId == UserGroupId.Trusted ? 500 : 100;
+
+		return requestTimes.Count < requestLimit;
+	}
+
+	public void IncrementCounter(IUserPermissionContext permissionContext)
+	{
+		var userId = permissionContext.LoggedUserId;
+		if (!_userEndpointRequests.ContainsKey(userId))
+		{
+			_userEndpointRequests[userId] = new List<DateTime>();
+		}
+
+		_userEndpointRequests[userId].Add(DateTime.Now);
+	}
+
+	public void RegisterEdit(IUserPermissionContext permissionContext)
+	{
+		if (permissionContext.UserGroupId == UserGroupId.Admin ||
+		    permissionContext.UserGroupId == UserGroupId.Moderator)
+		{
+			return;
+		}
+		
+		if (!permissionContext.IsLoggedIn || !IsAllowed(permissionContext))
+		{
+			throw new NotAllowedException();
+		}
+		else
+		{
+			IncrementCounter(permissionContext);
+		}
+	}
+}

--- a/VocaDbWeb/Startup.cs
+++ b/VocaDbWeb/Startup.cs
@@ -151,6 +151,8 @@ public class Startup
 					.AllowCredentials();
 			});
 		});
+
+		services.AddSingleton<EditRateLimitService>();
 	}
 
 	private static string[] LoadBlockedIPs(IComponentContext componentContext) => componentContext.Resolve<IRepository>().HandleQuery(q => q.Query<IPRule>().Select(i => i.Address).ToArray());


### PR DESCRIPTION
The new EditRateLimitService maintains a rolling window of 1 hour. The following limits apply
- 100 edit requests per hour (regular users)
- 500 edit requests per hour (trusted users)
- unlimited edit requests per hour (moderator & admin) 