### PR TITLE
Update WebLinkMatcher.ts

### DIFF
--- a/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
+++ b/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
@@ -349,16 +349,6 @@ export class WebLinkMatcher {
 			cat: WebLinkCategory.Official,
 		},
 		{
-			url: 'itunes.apple.com/',
-			desc: 'iTunes',
-			cat: WebLinkCategory.Commercial,
-		},
-		{
-			url: 'music.apple.com/',
-			desc: 'iTunes',
-			cat: WebLinkCategory.Commercial,
-		},
-		{
 			url: 'itunes.apple.com/us/',
 			desc: 'iTunes (US)',
 			cat: WebLinkCategory.Commercial,
@@ -376,6 +366,16 @@ export class WebLinkMatcher {
 		{
 			url: 'music.apple.com/jp/',
 			desc: 'iTunes (JP)',
+			cat: WebLinkCategory.Commercial,
+		},
+		{
+			url: 'itunes.apple.com/',
+			desc: 'iTunes',
+			cat: WebLinkCategory.Commercial,
+		},
+		{
+			url: 'music.apple.com/',
+			desc: 'iTunes',
 			cat: WebLinkCategory.Commercial,
 		},
 		{


### PR DESCRIPTION
Adjusted the order so that iTunes (JP) and iTunes (US) links will be matched *before* iTunes (country unspecified).