### PR TITLE
fix: Correctly compare culture codes for lyrics

### DIFF
--- a/VocaDbModel/Domain/Songs/LyricsForSong.cs
+++ b/VocaDbModel/Domain/Songs/LyricsForSong.cs
@@ -102,7 +102,7 @@ public class LyricsForSong : IEquatable<LyricsForSong>, IDatabaseObject
 			return false;
 
 		return (TranslationType == contract.TranslationType
-			&& CultureCodes.Select(c => c.CultureCode) == contract.CultureCodes
+			&& CultureCodes.Select(c => c.CultureCode).SequenceEqual(contract.CultureCodes ?? new string[] {})
 			&& Source == contract.Source
 			&& URL == contract.URL
 			&& Value == contract.Value);

--- a/VocaDbModel/Domain/Users/UserGroup.cs
+++ b/VocaDbModel/Domain/Users/UserGroup.cs
@@ -28,7 +28,9 @@ public class UserGroup
 		PermissionToken.ManageDatabase,
 		PermissionToken.EditTags,
 		PermissionToken.ReportUser,
-		PermissionToken.ManageEventSeries
+		PermissionToken.ManageEventSeries,
+		PermissionToken.ViewLyrics,
+		PermissionToken.ViewCoverArtImages
 	);
 
 	private static readonly UserGroup s_trusted = new(


### PR DESCRIPTION
Fixes a bug where lyrics are always included in `changedFields`.