### PR TITLE
Update WebLinkMatcher.ts

### DIFF
--- a/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
+++ b/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
@@ -919,7 +919,7 @@ export class WebLinkMatcher {
 			cat: WebLinkCategory.Reference,
 		} /* TouhouDB */,
 		{
-			url: 'en.touhouwiki.net/wiki/',
+			url: 'en.touhouwiki.net/',
 			desc: 'Touhou Wiki',
 			cat: WebLinkCategory.Reference,
 		} /* TouhouDB */,


### PR DESCRIPTION
Removed "wiki/" from the end of the matcher for Touhou Wiki, since articles don't necessarily include that part of the path.