### PR TITLE
feat: Support x.com in ArtistExternalUrlParser.cs

### DIFF
--- a/VocaDbModel/Service/Helpers/ArtistExternalUrlParser.cs
+++ b/VocaDbModel/Service/Helpers/ArtistExternalUrlParser.cs
@@ -12,7 +12,8 @@ public class ArtistExternalUrlParser
 	private static readonly RegexLinkMatcher[] linkMatchers = {
 		new RegexLinkMatcher("https://www.nicovideo.jp/{0}/{1}", @"^(?:http(?:s)?://www.nicovideo.jp)?/?(user|mylist)/(\d+)"),
 		// `twitter.com/name` or `t/name`.
-		new RegexLinkMatcher("https://twitter.com/{0}", @"^(?:http(?:s)?://twitter\.com|t)/(\w+)")
+		new RegexLinkMatcher("https://twitter.com/{0}", @"^(?:http(?:s)?://twitter\.com|t)/(\w+)"),
+		new RegexLinkMatcher("https://twitter.com/{0}", @"^(?:http(?:s)?://x\.com)/(\w+)")
 	};
 
 	private static readonly string[] whitelistedUrls = {


### PR DESCRIPTION
Closes #1805. We're mapping searches for x.com to twitter.com for now.

#1765 will normalize x.com to twitter.com URLs while editing external links in the future.