### PR TITLE
feat: /Details rate limiting

### DIFF
--- a/VocaDbModel/Domain/Constants.cs
+++ b/VocaDbModel/Domain/Constants.cs
@@ -20,4 +20,6 @@ public static class Constants
 	public const int AbsoluteMaxBpm = 1015;
 
 	public const decimal BpmStep = 0.01M;
+	
+	public const string RateLimitingDetailsPolicy = "details";
 }

--- a/VocaDbWeb/Controllers/Api/AlbumApiController.cs
+++ b/VocaDbWeb/Controllers/Api/AlbumApiController.cs
@@ -4,6 +4,7 @@ using AspNetCore.CacheOutput;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using VocaDb.Model.Database.Queries;
 using VocaDb.Model.DataContracts;
 using VocaDb.Model.DataContracts.Albums;
@@ -378,6 +379,7 @@ public class AlbumApiController : ApiController
 #nullable enable
 	[HttpGet("{id:int}/details")]
 	[ApiExplorerSettings(IgnoreApi = true)]
+	[EnableRateLimiting("details")]
 	public AlbumDetailsForApiContract GetDetails(int id)
 	{
 		WebHelper.VerifyUserAgent(Request);

--- a/VocaDbWeb/Controllers/Api/AlbumApiController.cs
+++ b/VocaDbWeb/Controllers/Api/AlbumApiController.cs
@@ -29,6 +29,7 @@ using VocaDb.Web.Code.Security;
 using VocaDb.Web.Helpers;
 using VocaDb.Web.Models.Shared;
 using ApiController = Microsoft.AspNetCore.Mvc.ControllerBase;
+using Constants = VocaDb.Model.Domain.Constants;
 
 namespace VocaDb.Web.Controllers.Api;
 
@@ -379,7 +380,7 @@ public class AlbumApiController : ApiController
 #nullable enable
 	[HttpGet("{id:int}/details")]
 	[ApiExplorerSettings(IgnoreApi = true)]
-	[EnableRateLimiting("details")]
+	[EnableRateLimiting(Constants.RateLimitingDetailsPolicy)]
 	public AlbumDetailsForApiContract GetDetails(int id)
 	{
 		WebHelper.VerifyUserAgent(Request);

--- a/VocaDbWeb/Controllers/Api/ArtistApiController.cs
+++ b/VocaDbWeb/Controllers/Api/ArtistApiController.cs
@@ -275,7 +275,7 @@ public class ArtistApiController : ApiController
 #nullable enable
 	[HttpGet("{id:int}/details")]
 	[ApiExplorerSettings(IgnoreApi = true)]
-	[EnableRateLimiting("details")]
+	[EnableRateLimiting(Constants.RateLimitingDetailsPolicy)]
 	public ArtistDetailsForApiContract GetDetails(int id)
 	{
 		WebHelper.VerifyUserAgent(Request);

--- a/VocaDbWeb/Controllers/Api/ArtistApiController.cs
+++ b/VocaDbWeb/Controllers/Api/ArtistApiController.cs
@@ -4,6 +4,7 @@ using System.Runtime.Caching;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using VocaDb.Model;
 using VocaDb.Model.Database.Queries;
 using VocaDb.Model.Database.Repositories;
@@ -274,6 +275,7 @@ public class ArtistApiController : ApiController
 #nullable enable
 	[HttpGet("{id:int}/details")]
 	[ApiExplorerSettings(IgnoreApi = true)]
+	[EnableRateLimiting("details")]
 	public ArtistDetailsForApiContract GetDetails(int id)
 	{
 		WebHelper.VerifyUserAgent(Request);

--- a/VocaDbWeb/Controllers/Api/SongApiController.cs
+++ b/VocaDbWeb/Controllers/Api/SongApiController.cs
@@ -33,6 +33,7 @@ using VocaDb.Web.Code.Security;
 using VocaDb.Web.Helpers;
 using VocaDb.Web.Models.Shared;
 using ApiController = Microsoft.AspNetCore.Mvc.ControllerBase;
+using Constants = VocaDb.Model.Domain.Constants;
 
 namespace VocaDb.Web.Controllers.Api;
 
@@ -556,7 +557,7 @@ public class SongApiController : ApiController
 #nullable enable
 	[HttpGet("{id:int}/details")]
 	[ApiExplorerSettings(IgnoreApi = true)]
-	[EnableRateLimiting("details")]
+	[EnableRateLimiting(Constants.RateLimitingDetailsPolicy)]
 	public SongDetailsForApiContract GetDetails(int id, int albumId = 0)
 	{
 		WebHelper.VerifyUserAgent(Request);

--- a/VocaDbWeb/Controllers/Api/SongApiController.cs
+++ b/VocaDbWeb/Controllers/Api/SongApiController.cs
@@ -4,6 +4,7 @@ using AspNetCore.CacheOutput;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using VocaDb.Model;
 using VocaDb.Model.Database.Queries;
 using VocaDb.Model.DataContracts;
@@ -555,6 +556,7 @@ public class SongApiController : ApiController
 #nullable enable
 	[HttpGet("{id:int}/details")]
 	[ApiExplorerSettings(IgnoreApi = true)]
+	[EnableRateLimiting("details")]
 	public SongDetailsForApiContract GetDetails(int id, int albumId = 0)
 	{
 		WebHelper.VerifyUserAgent(Request);

--- a/VocaDbWeb/Program.cs
+++ b/VocaDbWeb/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.RateLimiting;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using NLog.Web;
@@ -17,6 +18,17 @@ try
 
 	startup.ConfigureServices(builder.Services);
 
+	builder.Services.AddRateLimiter(options =>
+	{
+		options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+		options
+			.AddSlidingWindowLimiter(policyName: "details", options =>
+			{
+				options.Window = TimeSpan.FromMinutes(1);
+				options.PermitLimit = 40;
+				options.SegmentsPerWindow = 1;
+			});
+	});
 	builder.Host.UseServiceProviderFactory(new AutofacServiceProviderFactory());
 	builder.Host.ConfigureContainer<ContainerBuilder>(startup.ConfigureContainer);
 

--- a/VocaDbWeb/Startup.cs
+++ b/VocaDbWeb/Startup.cs
@@ -295,6 +295,8 @@ public class Startup
 		app.UseForwardedHeaders();
 
 		app.UseRouting();
+		
+		app.UseRateLimiter();
 
 		app.UseRequestLocalization(options =>
 		{


### PR DESCRIPTION
Closes #1596 and adds a 40 req/minute sliding window rate limit and a max. 4 concurrent requests limit for /details endpoints.