### PR TITLE
Change langversion to latest instead of preview for VocaDb.Model

### DIFF
--- a/VocaDbModel/VocaDb.Model.csproj
+++ b/VocaDbModel/VocaDb.Model.csproj
@@ -16,7 +16,7 @@
     </NuGetPackageImportStamp>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RuntimeIdentifiers>win</RuntimeIdentifiers>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseImageSharp>true</UseImageSharp>


### PR DESCRIPTION
I noticed the build was failing in AppVeyor and also my machine. VocaDb.Model project was set to langversion = preview, which enables "field" as reserved keyword. I think preview should only be used temporarily, because it can be unstable. It was probably set years ago to enable features that were preview at that time, and it's no longer needed. Microsoft recommends setting the language version to fixed value (such as 13), or removing it to use default, but I didn't want to start experimenting at this point. langversion = latest is better than preview, and it fixes the build, on my machine at least.