### PR TITLE
chores: Add new linkmatchers

### DIFF
--- a/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
+++ b/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
@@ -454,6 +454,11 @@ export class WebLinkMatcher {
 			cat: WebLinkCategory.Official,
 		},
 		{
+			url: 'fandub.wiki/',
+			desc: 'FanDub.Wiki',
+			cat: WebLinkCategory.Reference,
+		},
+		{
 			url: 'shop.fasic.jp/',
 			desc: 'fasic',
 			cat: WebLinkCategory.Commercial,

--- a/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
+++ b/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
@@ -455,7 +455,7 @@ export class WebLinkMatcher {
 		},
 		{
 			url: 'fandub.wiki/',
-			desc: 'FanDub.Wiki',
+			desc: 'FanDub.wiki',
 			cat: WebLinkCategory.Reference,
 		},
 		{

--- a/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
+++ b/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
@@ -684,6 +684,11 @@ export class WebLinkMatcher {
 			cat: WebLinkCategory.Official,
 		},
 		{
+			url: 'lyricstranslate.com/',
+			desc: 'LyricsTranslate.com',
+			cat: WebLinkCategory.Reference,
+		},
+		{
 			url: 'mailto:',
 			desc: 'e-mail',
 			cat: WebLinkCategory.Official,
@@ -1234,6 +1239,11 @@ export class WebLinkMatcher {
 			cat: WebLinkCategory.Commercial,
 		},
 		{
+			url: 't.me/',
+			desc: 'Telegram',
+			cat: WebLinkCategory.Official,
+		},
+		{
 			url: 'www.lagoa.jp/',
 			desc: 'THREE!',
 			cat: WebLinkCategory.Commercial,
@@ -1596,6 +1606,11 @@ export class WebLinkMatcher {
 		{
 			url: 'ja.wikipedia.org/wiki/',
 			desc: 'Wikipedia (JP)',
+			cat: WebLinkCategory.Reference,
+		},
+		{
+			url: 'ko.wikipedia.org/wiki/',
+			desc: 'Wikipedia (KR)',
 			cat: WebLinkCategory.Reference,
 		},
 		{

--- a/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
+++ b/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
@@ -274,6 +274,11 @@ export class WebLinkMatcher {
 			cat: WebLinkCategory.Commercial,
 		},
 		{
+			url: 'boosty.to/',
+			desc: 'Boosty',
+			cat: WebLinkCategory.Official,
+		},
+		{
 			url: 'booth.pm/',
 			desc: 'Booth',
 			cat: WebLinkCategory.Commercial,


### PR DESCRIPTION
- lyricstranslate - also often records translyrics
- telegram - frequently used in russia
- korean wikipedia - korean wikipedia :kr: :+1: 
- boosty: russian equivalent of patreon/ko-fi? also frequently seen
- fandub.wiki: russian youtaite wiki