### PR TITLE
Update WebLinkMatcher.ts

### DIFF
--- a/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
+++ b/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
@@ -575,7 +575,7 @@ export class WebLinkMatcher {
 		},
 		{
 			url: 'music.apple.com/us/',
-			desc: 'iTunes (US)',
+			desc: 'Apple Music (US)',
 			cat: WebLinkCategory.Commercial,
 		},
 		{
@@ -585,7 +585,7 @@ export class WebLinkMatcher {
 		},
 		{
 			url: 'music.apple.com/jp/',
-			desc: 'iTunes (JP)',
+			desc: 'Apple Music (JP)',
 			cat: WebLinkCategory.Commercial,
 		},
 		{
@@ -595,7 +595,7 @@ export class WebLinkMatcher {
 		},
 		{
 			url: 'music.apple.com/',
-			desc: 'iTunes',
+			desc: 'Apple Music',
 			cat: WebLinkCategory.Commercial,
 		},
 		{
@@ -610,7 +610,7 @@ export class WebLinkMatcher {
 		},
 		{
 			url: 'karent.jp/',
-			desc: 'KarenT',
+			desc: 'KARENT',
 			cat: WebLinkCategory.Commercial,
 		},
 		{
@@ -925,7 +925,7 @@ export class WebLinkMatcher {
 		},
 		{
 			url: 'nicovideo.jp/watch',
-			desc: 'NicoNicoDouga',
+			desc: 'Niconico',
 			cat: WebLinkCategory.Official,
 		},
 		{
@@ -1655,12 +1655,12 @@ export class WebLinkMatcher {
 		},
 		{
 			url: 'youtube.com/c/',
-			desc: 'YouTube Channel',
+			desc: 'YouTube Channel (Custom - c)',
 			cat: WebLinkCategory.Official,
 		},
 		{
 			url: 'youtube.com/@',
-			desc: 'YouTube Channel',
+			desc: 'YouTube Channel (Custom - @)',
 			cat: WebLinkCategory.Official,
 		},
 		{
@@ -1670,7 +1670,7 @@ export class WebLinkMatcher {
 		},
 		{
 			url: 'youtube.com/user/',
-			desc: 'YouTube Channel',
+			desc: 'YouTube Channel (Custom - user)',
 			cat: WebLinkCategory.Official,
 		},
 		{


### PR DESCRIPTION
Includes a few name changes in the WebLinkMatcher.ts, some of which have already been discussed.

iTunes → Apple Music
Applies to all Apple Music links (music.apple.com)

KarenT → KARENT

NicoNicoDouga → Niconico
See discussion on [VocaDB's Discord server](https://discordapp.com/channels/309072240639737866/1271565701601296506/1343417392717369464).
References: [Wikipedia](https://en.wikipedia.org/wiki/Niconico), [Official Twitter (X) account](https://x.com/niconicoen).

YouTube URL formats
See discussion on [VocaDB's Discord server](https://discordapp.com/channels/309072240639737866/1039922389301072014/1294231833680019497).
**Current** official names of the YouTube's URL formats can be found [here](https://support.google.com/youtube/answer/6180214?hl=en).
Since the YouTube channel URL format is the standard URL format, having all the other URL formats labeled as custom formats would make sense in case YouTube decides to make changes to those URL formats or their statuses in the future (as discussed).