### PR TITLE
Fix related albums thumbnails being blank

### DIFF
--- a/VocaDbModel/Database/Queries/AlbumQueries.cs
+++ b/VocaDbModel/Database/Queries/AlbumQueries.cs
@@ -638,17 +638,17 @@ public class AlbumQueries : QueriesBase<IAlbumRepository, Album>
 			{
 				ArtistMatches =
 					albums.ArtistMatches
-					.Select(a => new AlbumForApiContract(a, null, language, PermissionContext, null, fields, SongOptionalFields.None))
+					.Select(a => new AlbumForApiContract(a, null, language, PermissionContext, _imageUrlFactory, fields, SongOptionalFields.None))
 					.OrderBy(a => a.Name)
 					.ToArray(),
 				LikeMatches =
 					albums.LikeMatches
-					.Select(a => new AlbumForApiContract(a, null, language, PermissionContext, null, fields, SongOptionalFields.None))
+					.Select(a => new AlbumForApiContract(a, null, language, PermissionContext, _imageUrlFactory, fields, SongOptionalFields.None))
 					.OrderBy(a => a.Name)
 					.ToArray(),
 				TagMatches =
 					albums.TagMatches
-					.Select(a => new AlbumForApiContract(a, null, language, PermissionContext, null, fields, SongOptionalFields.None))
+					.Select(a => new AlbumForApiContract(a, null, language, PermissionContext, _imageUrlFactory, fields, SongOptionalFields.None))
 					.OrderBy(a => a.Name)
 					.ToArray()
 			};


### PR DESCRIPTION
Should fix blank thumbnails on the `Related albums` tab of album entries. Untested, blind fix based on how `IAggregatedEntryImageUrlFactory` is passed around.

There should probably be a warning or error when `AlbumOptionalFields.MainPicture` is requested and `thumbPersister` is null.

https://github.com/VocaDB/vocadb/blob/4fa0c9b2665df5612d589615e1eb8b855492d2ff/VocaDbModel/DataContracts/Albums/AlbumForApiContract.cs#L85-L90

## Blank thumbnails?

See for example: https://vocadb.net/Al/38012/related.

![slika](https://github.com/user-attachments/assets/35de7d24-4d89-49f7-ba28-2ee3a480a33f)
