### PR TITLE
Update WebLinkMatcher.ts

### DIFF
--- a/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
+++ b/VocaDbWeb/Scripts/Shared/WebLinkMatcher.ts
@@ -1539,6 +1539,11 @@ export class WebLinkMatcher {
 			cat: WebLinkCategory.Reference,
 		},
 		{
+			url: 'vocaloidlyrics.miraheze.org/wiki/',
+			desc: 'Vocaloid Lyrics Wiki',
+			cat: WebLinkCategory.Reference,
+		},
+		{
 			url: 'vocaloidia.com/',
 			desc: 'VocaloidIA',
 			cat: WebLinkCategory.Reference,


### PR DESCRIPTION
Updated WebLinkMatcher concerning Vocaloid Lyrics Wiki's migration to Miraheze.