### PR TITLE
perf: Only fetch minimal data for HTML metadata

### DIFF
--- a/VocaDbModel/DataContracts/Artists/ArtistForMetaTagsContract.cs
+++ b/VocaDbModel/DataContracts/Artists/ArtistForMetaTagsContract.cs
@@ -1,0 +1,60 @@
+using VocaDb.Model.DataContracts.Globalization;
+using VocaDb.Model.Domain;
+using VocaDb.Model.Domain.Artists;
+using VocaDb.Model.Domain.Globalization;
+using VocaDb.Model.Domain.Images;
+using VocaDb.Model.Domain.Security;
+
+namespace VocaDb.Model.DataContracts.Artists;
+
+/// <summary>
+/// Minimal artist data contract for server-side rendering meta tags (OpenGraph, etc.).
+/// Contains only the fields needed for SEO and social media previews.
+/// </summary>
+public sealed record ArtistForMetaTagsContract
+{
+	public ArtistType ArtistType { get; init; }
+
+	public bool Deleted { get; init; }
+
+	public EnglishTranslatedStringContract Description { get; init; }
+
+	public EntryThumbForApiContract? MainPicture { get; init; }
+
+	public string Name { get; init; }
+
+	public DateTime? ReleaseDate { get; init; }
+
+	public ArtistForApiContract[] VoiceProviders { get; init; }
+
+	public ArtistForMetaTagsContract(
+		Artist artist,
+		ContentLanguagePreference languagePreference,
+		IAggregatedEntryImageUrlFactory imageStore,
+		IUserPermissionContext userContext
+	)
+	{
+		ArtistType = artist.ArtistType;
+		Deleted = artist.Deleted;
+		Description = new EnglishTranslatedStringContract(artist.Description);
+		Name = artist.TranslatedName[languagePreference];
+		ReleaseDate = artist.ReleaseDate.DateTime;
+
+		MainPicture = artist.Thumb is not null
+			? new EntryThumbForApiContract(image: artist.Thumb, thumbPersister: imageStore)
+			: null;
+
+		// VoiceProviders are needed for the description generator
+		VoiceProviders = artist
+			.ArtistLinksOfType(ArtistLinkType.VoiceProvider, LinkDirection.ManyToOne, allowInheritance: true)
+			.Select(g => new ArtistForApiContract(
+				artist: g,
+				languagePreference: languagePreference,
+				userContext,
+				thumbPersister: null,
+				includedFields: ArtistOptionalFields.None
+			))
+			.OrderBy(a => a.Name)
+			.ToArray();
+	}
+}

--- a/VocaDbModel/DataContracts/Songs/SongForMetaTagsContract.cs
+++ b/VocaDbModel/DataContracts/Songs/SongForMetaTagsContract.cs
@@ -1,0 +1,44 @@
+using VocaDb.Model.DataContracts.Globalization;
+using VocaDb.Model.Domain.Globalization;
+using VocaDb.Model.Domain.Songs;
+using VocaDb.Model.Service.VideoServices;
+
+namespace VocaDb.Model.DataContracts.Songs;
+
+/// <summary>
+/// Minimal song data contract for server-side rendering meta tags (OpenGraph, etc.).
+/// Contains only the fields needed for SEO and social media previews.
+/// </summary>
+public sealed record SongForMetaTagsContract
+{
+	public string ArtistString { get; init; }
+
+	public bool Deleted { get; init; }
+
+	public string Name { get; init; }
+
+	public EnglishTranslatedStringContract Notes { get; init; }
+
+	public DateTime? PublishDate { get; init; }
+
+	public SongType SongType { get; init; }
+
+	public string? ThumbUrlMaxSize { get; init; }
+
+	public SongForMetaTagsContract(
+		Song song,
+		ContentLanguagePreference languagePreference
+	)
+	{
+		ArtistString = song.ArtistString[languagePreference];
+		Deleted = song.Deleted;
+		Name = song.TranslatedName[languagePreference];
+		Notes = new EnglishTranslatedStringContract(song.Notes);
+		PublishDate = song.PublishDate;
+		SongType = song.SongType;
+
+		// Get thumbnail URL for OpenGraph image from PVs
+		var thumbUrl = VideoServiceHelper.GetThumbUrlPreferNotNico(song.PVs.PVs);
+		ThumbUrlMaxSize = VideoServiceHelper.GetMaxSizeThumbUrl(song.PVs.PVs) ?? thumbUrl;
+	}
+}

--- a/VocaDbModel/Database/Queries/ArtistQueries.cs
+++ b/VocaDbModel/Database/Queries/ArtistQueries.cs
@@ -477,6 +477,21 @@ public class ArtistQueries : QueriesBase<IArtistRepository, Artist>
 			return contract;
 		});
 	}
+
+	public ArtistForMetaTagsContract GetForMetaTags(int id)
+	{
+		return HandleQuery(session =>
+		{
+			var artist = session.Load(id);
+
+			return new ArtistForMetaTagsContract(
+				artist: artist,
+				languagePreference: LanguagePreference,
+				imageStore: _imageUrlFactory,
+				userContext: PermissionContext
+			);
+		});
+	}
 #nullable disable
 
 	public T GetWithMergeRecord<T>(int id, Func<Artist, ArtistMergeRecord, IDatabaseContext<Artist>, T> fac)

--- a/VocaDbModel/Database/Queries/SongQueries.cs
+++ b/VocaDbModel/Database/Queries/SongQueries.cs
@@ -685,6 +685,19 @@ public class SongQueries : QueriesBase<ISongRepository, Song>
 		});
 	}
 
+	public SongForMetaTagsContract GetForMetaTags(int songId)
+	{
+		return HandleQuery(session =>
+		{
+			var song = session.Load<Song>(songId);
+
+			return new SongForMetaTagsContract(
+				song: song,
+				languagePreference: PermissionContext.LanguagePreference
+			);
+		});
+	}
+
 	public SongWithPVAndVoteForApiContract GetSongWithPVAndVote(int songId, bool addHit, string hostname = "", bool includePVs = true)
 	{
 		return HandleQuery(session =>

--- a/VocaDbModel/Service/ExtSites/ArtistDescriptionGenerator.cs
+++ b/VocaDbModel/Service/ExtSites/ArtistDescriptionGenerator.cs
@@ -20,7 +20,35 @@ public class ArtistDescriptionGenerator
 		}
 	}
 
+	private void AddVoicebankDetails(StringBuilder sb, ArtistForMetaTagsContract artist)
+	{
+		if (artist.ReleaseDate.HasValue)
+		{
+			sb.AppendFormat(" Released {0}.", artist.ReleaseDate.Value.ToShortDateString());
+		}
+
+		if (artist.VoiceProviders.Any())
+		{
+			sb.AppendFormat(" Voice provider: {0}.", string.Join(", ", artist.VoiceProviders.Select(a => a.Name)));
+		}
+	}
+
 	public string GenerateDescription(ArtistDetailsForApiContract artist, string? original, TranslateableEnum<ArtistType> artistTypeNames)
+	{
+		var sb = new StringBuilder(original);
+
+		// Note: if original description is not empty, artist type is added to title instead of description
+		if (string.IsNullOrEmpty(original))
+		{
+			sb.AppendFormat("{0}.", artistTypeNames[artist.ArtistType]);
+		}
+
+		AddVoicebankDetails(sb, artist);
+
+		return sb.ToString();
+	}
+
+	public string GenerateDescription(ArtistForMetaTagsContract artist, string? original, TranslateableEnum<ArtistType> artistTypeNames)
 	{
 		var sb = new StringBuilder(original);
 

--- a/VocaDbWeb/Controllers/ArtistController.cs
+++ b/VocaDbWeb/Controllers/ArtistController.cs
@@ -113,7 +113,8 @@ public class ArtistController : ControllerBase
 
 		WebHelper.VerifyUserAgent(Request);
 
-		var model = _queries.GetDetailsForApi(id, GetHostnameForValidHit());
+		// Use minimal data fetch for server-side rendering - only loads data needed for meta tags
+		var model = _queries.GetForMetaTags(id);
 
 		var prop = PageProperties;
 		prop.GlobalSearchType = EntryType.Artist;


### PR DESCRIPTION
This should greatly reduce the latency for loading song and artist entry pages. Previously we fetched an entire SongDetails/ArtistDetails object for every `/S/<song_id>` or `/Ar/<artist_id>` load. These objects contain a lot of data that is not actually required to return the page. With these changes we only fetch the minimal data required for HTML metadata tags.

Please note that this does not affect navigation from an already loaded VocaDB page to a new song or artist page.