### PR TITLE
fix: Add version strings to image URLs

### DIFF
--- a/VocaDbModel/Domain/Images/S3EntryImagePersister.cs
+++ b/VocaDbModel/Domain/Images/S3EntryImagePersister.cs
@@ -187,8 +187,11 @@ namespace VocaDb.Model.Domain.Images
         public VocaDbUrl GetUrl(IEntryImageInformation picture, ImageSize size)
         {
             var key = GetKey(picture, size);
+            var url = (picture.Version > 0)
+                ? $"{key}?v={picture.Version}"
+                : key;
 
-            return new VocaDbUrl(key, UrlDomain.Static, UriKind.Relative);
+            return new VocaDbUrl(url, UrlDomain.Static, UriKind.Relative);
         }
 
         public bool HasImage(IEntryImageInformation picture, ImageSize size)


### PR DESCRIPTION
Related to #1994. This should fix the current image upload bugs.