### PR TITLE
Add "npm run dev:beta" command

### DIFF
--- a/VocaDbWeb/package.json
+++ b/VocaDbWeb/package.json
@@ -1,6 +1,7 @@
 {
 	"private": true,
 	"scripts": {
+		"dev:beta": "cross-env --mode=beta vite",
 		"dev": "npm run development",
 		"development": "vite",
 		"prod": "npm run production",
@@ -28,7 +29,7 @@
 		"@typescript-eslint/eslint-plugin": "^5.40.1",
 		"@typescript-eslint/parser": "^5.40.1",
 		"@vitejs/plugin-react": "^4.3.4",
-		"cross-env": "^5.1",
+		"cross-env": "^5.2.1",
 		"eslint": "^8.42.0",
 		"eslint-config-prettier": "^8.8.0",
 		"eslint-config-react-app": "^7.0.1",

--- a/VocaDbWeb/vite.config.ts
+++ b/VocaDbWeb/vite.config.ts
@@ -7,6 +7,8 @@ import { defineConfig, loadEnv } from 'vite';
 export default defineConfig(({ mode }) => {
 	const env = loadEnv(mode, process.cwd());
 	const VITE_FARO_API_KEY = `${env.VITE_FARO_API_KEY ?? ''}`;
+	const betaMode = process.env.mode === 'beta';
+	console.log('Using https://beta.vocadb.net/ :', betaMode);
 
 	return {
 		build: {
@@ -37,13 +39,15 @@ export default defineConfig(({ mode }) => {
 		server: {
 			proxy: {
 				'/api': {
-					target: 'https://vocadb.net',
+					target: betaMode ? 'https://beta.vocadb.net' : 'https://vocadb.net',
 					changeOrigin: true,
 					// https://stackoverflow.com/questions/74033733/vite-self-signed-certificate-error-when-calling-local-api/74033815#74033815
 					secure: false,
 				},
 				'^/stats/.*': {
-					target: 'https://localhost:5001',
+					target: betaMode
+						? 'https://beta.vocadb.net'
+						: 'https://localhost:5001',
 					changeOrigin: true,
 					// https://stackoverflow.com/questions/74033733/vite-self-signed-certificate-error-when-calling-local-api/74033815#74033815
 					secure: false,


### PR DESCRIPTION
Add "npm run dev:beta" command to remove the need for manual config file editing.

Part of fixing up https://wiki.vocadb.net/docs/front-end-only-development-environment

Unfamiliar with the current build pipeline so doing this through a PR.