### PR TITLE
fix: Split Other/Unknown and make it searchable

### DIFF
--- a/VocaDb.Migrations/Migrations.cs
+++ b/VocaDb.Migrations/Migrations.cs
@@ -4,6 +4,22 @@ using FluentMigrator;
 
 namespace VocaDb.Migrations;
 
+[Migration(2026_01_21_0000)]
+public class MigrateEmptyCultureCodesToUnknown : Migration
+{
+	public override void Up()
+	{
+		Execute.Sql($"UPDATE {TableNames.CultureCodesForLyrics} SET CultureCode = 'und' WHERE CultureCode = ''");
+		Execute.Sql($"UPDATE {TableNames.CultureCodesForSongs} SET CultureCode = 'und' WHERE CultureCode = ''");
+		Execute.Sql($"UPDATE {TableNames.CultureCodesForArtists} SET CultureCode = 'und' WHERE CultureCode = ''");
+		Execute.Sql($"UPDATE UserKnownLanguages SET CultureCode = 'und' WHERE CultureCode = ''");
+	}
+
+	public override void Down()
+	{
+	}
+}
+
 [Migration(2026_01_08_0000)]
 public class AddConfigTable : Migration
 {

--- a/VocaDbWeb/Scripts/Components/extendedUserLanguageCultures.ts
+++ b/VocaDbWeb/Scripts/Components/extendedUserLanguageCultures.ts
@@ -673,6 +673,13 @@ const rawLangs: RawLangs = [
 		},
 	],
 	[
+		'qot',
+		{
+			languages: ['Other'],
+			nativeName: 'Other',
+		},
+	],
+	[
 		'och',
 		{
 			languages: ['Old Chinese', 'Archaic Chinese'],
@@ -988,6 +995,13 @@ const rawLangs: RawLangs = [
 		{
 			languages: ['Uyghur', 'Uighur', ' Eastern Turki'],
 			nativeName: 'ئۇيغۇرچە',
+		},
+	],
+	[
+		'und',
+		{
+			languages: ['Unknown'],
+			nativeName: 'Unknown',
 		},
 	],
 	[

--- a/VocaDbWeb/Scripts/Components/userLanguageCultures.ts
+++ b/VocaDbWeb/Scripts/Components/userLanguageCultures.ts
@@ -1,3 +1,6 @@
+export const CULTURE_CODE_OTHER = 'qot';
+export const CULTURE_CODE_UNKNOWN = 'und';
+
 export const userLanguageCultures = Object.fromEntries(
 	Object.entries({
 		de: { nativeName: 'Deutsch', englishName: 'German' },
@@ -9,6 +12,7 @@ export const userLanguageCultures = Object.fromEntries(
 		it: { nativeName: 'italiano', englishName: 'Italian' },
 		nl: { nativeName: 'Nederlands', englishName: 'Dutch' },
 		no: { nativeName: 'norsk', englishName: 'Norwegian' },
+		[CULTURE_CODE_OTHER]: { nativeName: 'Other', englishName: 'Other' },
 		pl: { nativeName: 'polski', englishName: 'Polish' },
 		pt: { nativeName: 'portugu\u00EAs', englishName: 'Portuguese' },
 		fi: { nativeName: 'suomi', englishName: 'Finnish' },
@@ -18,6 +22,7 @@ export const userLanguageCultures = Object.fromEntries(
 			englishName: 'Russian',
 		},
 		th: { nativeName: '\u0E44\u0E17\u0E22', englishName: 'Thai' },
+		[CULTURE_CODE_UNKNOWN]: { nativeName: 'Unknown', englishName: 'Unknown' },
 		ko: { nativeName: '\uD55C\uAD6D\uC5B4', englishName: 'Korean' },
 		zh: { nativeName: '\u4E2D\u6587', englishName: 'Chinese' },
 		ja: { nativeName: '\u65E5\u672C\u8A9E', englishName: 'Japanese' },

--- a/VocaDbWeb/Scripts/Pages/Song/Partials/LyricsForSongEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/Partials/LyricsForSongEdit.tsx
@@ -2,6 +2,7 @@ import Accordion from '@/Bootstrap/Accordion';
 import SafeAnchor from '@/Bootstrap/SafeAnchor';
 import { UserLanguageCultureDropdownList } from '@/Components/Shared/Partials/Knockout/DropdownList';
 import { HelpLabel } from '@/Components/Shared/Partials/Shared/HelpLabel';
+import { CULTURE_CODE_UNKNOWN } from '@/Components/userLanguageCultures';
 import { useCultureCodes } from '@/CultureCodesContext';
 import { useLoginManager } from '@/LoginManagerContext';
 import {
@@ -92,10 +93,7 @@ const LyricsForSongEdit = observer(
 													<td>
 														<UserLanguageCultureDropdownList
 															key={index}
-															placeholder={t(
-																'VocaDb.Web.Resources.Domain.Globalization:InterfaceLanguage.Other',
-															)}
-															value={cultureCode}
+															value={cultureCode || CULTURE_CODE_UNKNOWN}
 															extended={languageOptionsExtended}
 															onChange={(e): void =>
 																runInAction(() => {

--- a/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
+++ b/VocaDbWeb/Scripts/Pages/Song/SongEdit.tsx
@@ -5,6 +5,7 @@ import Button from '@/Bootstrap/Button';
 import SafeAnchor from '@/Bootstrap/SafeAnchor';
 import { ArtistAutoComplete } from '@/Components/KnockoutExtensions/ArtistAutoComplete';
 import { NamesEditor } from '@/Components/Shared/KnockoutPartials/NamesEditor';
+import { CULTURE_CODE_UNKNOWN } from '@/Components/userLanguageCultures';
 import { Layout } from '@/Components/Shared/Layout';
 import { PVEdit } from '@/Components/Shared/PVs/PVEdit';
 import { ArtistRolesEditViewModel } from '@/Components/Shared/Partials/ArtistRolesEditViewModel';
@@ -410,10 +411,7 @@ const BasicInfoTabContent = observer(
 								{songEditStore.cultureCodes.items.map((c, index) => (
 									<tr key={index}>
 										<UserLanguageCultureDropdownList
-											value={c.toString()}
-											placeholder={t(
-												'VocaDb.Web.Resources.Domain.Globalization:InterfaceLanguage.Other',
-											)}
+											value={c.toString() || CULTURE_CODE_UNKNOWN}
 											extended={songEditStore.cultureCodes.extended}
 											onChange={(val): void => {
 												songEditStore.cultureCodes.items[index] =

--- a/VocaDbWeb/public/locales/en/VocaDb.Web.Resources.Domain.Globalization.json
+++ b/VocaDbWeb/public/locales/en/VocaDb.Web.Resources.Domain.Globalization.json
@@ -1,6 +1,7 @@
 {
   "InterfaceLanguage": {
-    "Other": "Other/Unknown"
+    "Other": "Other",
+    "Unknown": "Unknown"
   },
   "TranslationTypeNames": {
     "Original": "Original",

--- a/VocaDbWeb/public/locales/ja/VocaDb.Web.Resources.Domain.Globalization.json
+++ b/VocaDbWeb/public/locales/ja/VocaDb.Web.Resources.Domain.Globalization.json
@@ -1,6 +1,7 @@
 {
   "InterfaceLanguage": {
-    "Other": "その他/不明"
+    "Other": "その他",
+    "Unknown": "不明"
   },
   "TranslationTypeNames": {
     "Original": "原文",

--- a/VocaDbWeb/public/locales/zh-Hans/VocaDb.Web.Resources.Domain.Globalization.json
+++ b/VocaDbWeb/public/locales/zh-Hans/VocaDb.Web.Resources.Domain.Globalization.json
@@ -1,6 +1,7 @@
 {
   "InterfaceLanguage": {
-    "Other": "其他/未知"
+    "Other": "其他",
+    "Unknown": "未知"
   },
   "TranslationTypeNames": {
     "Original": "原文",


### PR DESCRIPTION
This PR splits Other/Unknown into two separate options "Other" and "Unknown" and adds both to the song and artist search filter.