### PR TITLE
feat: Album image maintenance

### DIFF
--- a/VocaDbWeb/Controllers/AlbumController.cs
+++ b/VocaDbWeb/Controllers/AlbumController.cs
@@ -283,6 +283,16 @@ public class AlbumController : ControllerBase
 		return RedirectToAction("Deleted");
 	}
 
+	[Authorize]
+	public ActionResult RegenerateImages(int id)
+	{
+		_queries.RegenerateImages(id);
+
+		TempData.SetSuccessMessage("Image variants regenerated");
+
+		return RedirectToAction("Details", new { id });
+	}
+
 	public ActionResult UsersWithAlbumInCollection(int albumId = InvalidId)
 	{
 		if (albumId == InvalidId)

--- a/VocaDbWeb/Scripts/Pages/Album/AlbumDetails.tsx
+++ b/VocaDbWeb/Scripts/Pages/Album/AlbumDetails.tsx
@@ -10,6 +10,7 @@ import { TagsEdit } from '@/Components/Shared/Partials/TagsEdit';
 import { AlbumDetailsForApi } from '@/DataContracts/Album/AlbumDetailsForApi';
 import { PVHelper } from '@/Helpers/PVHelper';
 import JQueryUIButton from '@/JQueryUI/JQueryUIButton';
+import JQueryUIDialog from '@/JQueryUI/JQueryUIDialog';
 import { useLoginManager } from '@/LoginManagerContext';
 import {
 	AlbumReportType,
@@ -165,6 +166,22 @@ const AlbumDetailsLayout = observer(
 						>
 							{t('ViewRes:EntryDetails.ReportAnError')}
 						</JQueryUIButton>{' '}
+						{loginManager.canAccessManageMenu && (
+							<>
+								<JQueryUIButton
+									as={SafeAnchor}
+									href="#"
+									onClick={(): void =>
+										runInAction(() => {
+											albumDetailsStore.maintenanceDialogVisible = true;
+										})
+									}
+									icons={{ primary: 'ui-icon-wrench' }}
+								>
+									Maintenance actions{/* LOC */}
+								</JQueryUIButton>
+							</>
+						)}{' '}
 						<EntryStatusMessage status={model.status} />
 					</>
 				}
@@ -200,6 +217,28 @@ const AlbumDetailsLayout = observer(
 						notesRequired: albumReportTypesWithRequiredNotes.includes(r),
 					}))}
 				/>
+
+				<JQueryUIDialog
+					title="Maintenance actions" /* LOC */
+					autoOpen={albumDetailsStore.maintenanceDialogVisible}
+					width={400}
+					close={(): void =>
+						runInAction(() => {
+							albumDetailsStore.maintenanceDialogVisible = false;
+						})
+					}
+				>
+					<div>
+						<p>
+							<JQueryUIButton
+								as="a"
+								href={`/Album/RegenerateImages/${model.id}`}
+							>
+								Regenerate image variants{/* LOC */}
+							</JQueryUIButton>
+						</p>
+					</div>
+				</JQueryUIDialog>
 			</Layout>
 		);
 	},

--- a/VocaDbWeb/Scripts/Stores/Album/AlbumDetailsStore.ts
+++ b/VocaDbWeb/Scripts/Stores/Album/AlbumDetailsStore.ts
@@ -272,6 +272,7 @@ export class AlbumDetailsStore {
 	@observable userHasAlbum;
 	@observable usersContent?: string;
 	@observable userCollectionsPopupVisible = false;
+	@observable maintenanceDialogVisible = false;
 
 	constructor(
 		private readonly values: GlobalValues,


### PR DESCRIPTION
Adds a maintenance menu for albums. Initially only with one option to regenerate album cover image size variants to fix failed image uploads.