### PR TITLE
fix: Refetch playlist after songlist size is known

### DIFF
--- a/VocaDbWeb/Scripts/Stores/VdbPlayer/PlayQueueStore.ts
+++ b/VocaDbWeb/Scripts/Stores/VdbPlayer/PlayQueueStore.ts
@@ -768,6 +768,11 @@ export class PlayQueueStore
 
 		await this.updateResultsWithTotalCount();
 
+		if (autoplayContext.shuffle && this.paging.totalItems > 0) {
+			this.items = [];
+			await this.updateResultsWithoutTotalCount();
+		}
+
 		this.setCurrentItem(this.items[0]);
 
 		if (this.shouldSkipCurrentItem) {


### PR DESCRIPTION
Fixes #1944 (shuffle always starting with the first song). The second bug can only be fixed by implementing something like the Fisher–Yates shuffle.