### PR TITLE
Add more YouTube link matchers

### DIFF
--- a/VocaDbModel/Service/VideoServices/VideoService.cs
+++ b/VocaDbModel/Service/VideoServices/VideoService.cs
@@ -57,6 +57,9 @@ public class VideoService : IVideoService
 			{
 				new RegexLinkMatcher("youtu.be/{0}", @"youtu.be/(\S{11})"),
 				new RegexLinkMatcher("www.youtube.com/watch?v={0}", @"youtube.com/watch?\S*v=(\S{11})"),
+				new RegexLinkMatcher("www.youtube.com/watch?v={0}", @"youtube.com/shorts/(\S{11})"),
+				new RegexLinkMatcher("www.youtube.com/watch?v={0}", @"youtube.com/watch/(\S{11})"),
+				new RegexLinkMatcher("www.youtube.com/watch?v={0}", @"youtube.com/video/(\S{11})"),
 			}
 		);
 
@@ -165,3 +168,4 @@ public class VideoService : IVideoService
 		return VideoUrlParseResult.CreateOk(url, Service, id, meta);
 	}
 }
+


### PR DESCRIPTION
This PR adds more YouTube link matchers that works on YouTube.

- `/shorts/`: different GUI (YouTube Shorts) (resolves #2072)
  - e.g. https://www.youtube.com/shorts/f4cehFwKA4g 
- `/watch/`: works (loads video like `watch?v=`), but updates URL to `watch?v=` after finished loading
  - e.g. https://www.youtube.com/watch/f4cehFwKA4g 
- `/video/`: redirects to `watch?v=` (similar to `youtu.be`)
  - e.g. https://www.youtube.com/video/f4cehFwKA4g 

> [!IMPORTANT] 
>
> This change is untested as setting up VocaDB is a chore that I couldn't handle for now, but changes are made based on existing codebase, so it *should* be fine.