### PR TITLE
 Remove filtering when dumping PVs 

### DIFF
--- a/VocaDbModel/Service/DataSharing/DatabaseDumper.cs
+++ b/VocaDbModel/Service/DataSharing/DatabaseDumper.cs
@@ -150,7 +150,7 @@ public sealed class DatabaseDumper
 		{
 			MainPictureMime = null;
 			Pictures = null;
-			PVs = PVs?.Where(pv => pv.PVType == Domain.PVs.PVType.Original).ToArray();
+			PVs = PVs?.ToArray();
 			Tags = album.Tags.Usages.Select(tagUsage => new ArchivedTagUsageContract(tagUsage)).ToArray();
 		}
 	}
@@ -165,7 +165,7 @@ public sealed class DatabaseDumper
 			: base(song, new SongDiff())
 		{
 			Lyrics = null;
-			PVs = PVs?.Where(pv => pv.PVType == Domain.PVs.PVType.Original).ToArray();
+			PVs = PVs?.ToArray();
 			Tags = song.Tags.Usages.Select(tagUsage => new ArchivedTagUsageContract(tagUsage)).ToArray();
 		}
 	}


### PR DESCRIPTION
This PR removes the filtering on PVs when dumping albums and songs. This should include PVs with `Other` and `Reprint` types, which can be useful on some cases, such as using the dump to update the view pool, which has been agreed to also include these PVs. The field describing the type still on the dump, so it could still be differentiated.

This PR is untested, though theoretically should work based on the syntax.