### PR TITLE
Issue 2056: Half-star Ratings for Albums

### DIFF
--- a/VocaDb.Migrations/Migrations.cs
+++ b/VocaDb.Migrations/Migrations.cs
@@ -4,6 +4,26 @@ using FluentMigrator;
 
 namespace VocaDb.Migrations;
 
+[Migration(2026_05_14_1633)]
+public class ChangeRatingColumnsToDecimal : Migration
+{
+	public override void Up()
+	{
+		// Per-user rating: allow one decimal place (e.g. 0.5)
+		Alter.Column("Rating").OnTable(TableNames.AlbumsForUsers).AsDecimal(3, 1).NotNullable().WithDefaultValue(0.0m);
+
+		// Album aggregate total: allow one decimal place and larger range for totals
+		Alter.Column("RatingTotal").OnTable(TableNames.Albums).AsDecimal(9, 1).NotNullable().WithDefaultValue(0.0m);
+	}
+
+	public override void Down()
+	{
+		// Revert to previous integer columns
+		Alter.Column("Rating").OnTable(TableNames.AlbumsForUsers).AsInt32().NotNullable().WithDefaultValue(0);
+		Alter.Column("RatingTotal").OnTable(TableNames.Albums).AsInt32().NotNullable().WithDefaultValue(0);
+	}
+}
+
 [Migration(2026_02_23_0000)]
 public class ExpandAdditionalNamesString : Migration
 {

--- a/VocaDbModel/DataContracts/Albums/AlbumDetailsContract.cs
+++ b/VocaDbModel/DataContracts/Albums/AlbumDetailsContract.cs
@@ -141,7 +141,7 @@ public class SharedAlbumStatsContract
 	public AlbumReviewContract LatestReview { get; init; }
 
 	[DataMember]
-	public int LatestReviewRatingScore { get; init; }
+	public double LatestReviewRatingScore { get; init; }
 
 	[DataMember]
 	public int OwnedCount { get; init; }

--- a/VocaDbModel/DataContracts/Users/AlbumForUserContract.cs
+++ b/VocaDbModel/DataContracts/Users/AlbumForUserContract.cs
@@ -54,7 +54,7 @@ public class AlbumForUserContract
 	public PurchaseStatus PurchaseStatus { get; init; }
 
 	[DataMember]
-	public int Rating { get; init; }
+	public double Rating { get; init; }
 
 	// Note: only needed for album collection. True if public collection or viewer is the user himself.
 	public bool ShouldShowCollectionStatus { get; init; }

--- a/VocaDbModel/DataContracts/Users/AlbumForUserForApiContract.cs
+++ b/VocaDbModel/DataContracts/Users/AlbumForUserForApiContract.cs
@@ -27,7 +27,7 @@ public class AlbumForUserForApiContract
 		Album = albumForUser != null
 			? new AlbumForApiContract(albumForUser.Album, null, languagePreference, permissionContext, thumbPersister, fields, SongOptionalFields.None)
 			: null;
-		Rating = albumForUser?.Rating ?? 0;
+		Rating = albumForUser?.Rating ?? 0.0;
 
 		if (shouldShowCollectionStatus)
 		{
@@ -61,7 +61,7 @@ public class AlbumForUserForApiContract
 	/// Given rating, generally from 0 to 5.
 	/// </summary>
 	[DataMember]
-	public int Rating { get; init; }
+	public double Rating { get; init; }
 
 	[DataMember]
 	public UserForApiContract User { get; init; }

--- a/VocaDbModel/Database/Queries/TagQueries.cs
+++ b/VocaDbModel/Database/Queries/TagQueries.cs
@@ -402,7 +402,7 @@ public class TagQueries : QueriesBase<ITagRepository, Tag>
 		return await _cache.GetOrInsertAsync(key, CachePolicy.AbsoluteExpiration(hours: 1), async () =>
 		{
 			var artists = await GetTopUsagesAndCountAsync<ArtistTagUsage, Artist, int>(ctx, tagId, t => !t.Entry.Deleted, t => t.Entry.Id, t => t.Entry);
-			var albums = await GetTopUsagesAndCountAsync<AlbumTagUsage, Album, int>(ctx, tagId, t => !t.Entry.Deleted, t => t.Entry.RatingTotal, t => t.Entry);
+			var albums = await GetTopUsagesAndCountAsync<AlbumTagUsage, Album, double>(ctx, tagId, t => !t.Entry.Deleted, t => t.Entry.RatingTotal, t => t.Entry);
 			var songLists = await GetTopUsagesAndCountAsync<SongListTagUsage, SongList, int>(ctx, tagId, t => !t.Entry.Deleted, t => t.Entry.Id, t => t.Entry);
 			var songs = await GetTopUsagesAndCountAsync<SongTagUsage, Song, int, SongType>(ctx, tagId, EntryType.Song, (query, etm) => query.WhereHasTypeOrTag(etm));
 			var eventSeries = await GetTopUsagesAndCountAsync<EventSeriesTagUsage, ReleaseEventSeries, int>(ctx, tagId, t => !t.Entry.Deleted, t => t.Entry.Id, t => t.Entry, maxCount: 6);
@@ -720,7 +720,7 @@ public class TagQueries : QueriesBase<ITagRepository, Tag>
 			}
 
 			diff.Description.Set(target.Description.CopyIfEmpty(source.Description));
-			
+
 			// Targets
 			if (!target.NewTargets.SequenceEqual(source.NewTargets))
 			{
@@ -917,9 +917,9 @@ public class TagQueries : QueriesBase<ITagRepository, Tag>
 			if (tag.HideFromSuggestions != contract.HideFromSuggestions)
 				diff.HideFromSuggestions.Set();
 
-			if (!tag.NewTargets.SequenceEqual(contract.NewTargets)) 
+			if (!tag.NewTargets.SequenceEqual(contract.NewTargets))
 				diff.Targets.Set();
-			
+
 			if (tag.Targets != (TagTargetTypes)contract.Targets)
 				diff.Targets.Set();
 

--- a/VocaDbModel/Database/Queries/UserQueries.cs
+++ b/VocaDbModel/Database/Queries/UserQueries.cs
@@ -1903,7 +1903,7 @@ public class UserQueries : QueriesBase<IUserRepository, User>
 		int albumId,
 		PurchaseStatus status,
 		MediaType mediaType,
-		int rating
+		double rating
 	)
 	{
 		PermissionContext.VerifyPermission(PermissionToken.EditProfile);

--- a/VocaDbModel/Domain/Albums/Album.cs
+++ b/VocaDbModel/Domain/Albums/Album.cs
@@ -371,7 +371,7 @@ public class Album :
 
 	public virtual int RatingCount { get; set; }
 
-	public virtual int RatingTotal { get; set; }
+	public virtual double RatingTotal { get; set; }
 
 	public virtual IList<AlbumReview> AllReviews
 	{
@@ -943,7 +943,7 @@ public class Album :
 	{
 		RatingCount = UserCollections.Where(a => a.Rating != AlbumForUser.NotRated).Count();
 		RatingTotal = UserCollections.Sum(a => a.Rating);
-		RatingAverageInt = RatingCount > 0 ? (RatingTotal * 100 / RatingCount) : 0;
+		RatingAverageInt = RatingCount > 0 ? (int)(RatingTotal * 100 / RatingCount) : 0;
 	}
 
 	public virtual Object TagSubtype()

--- a/VocaDbModel/Domain/Users/AlbumForUser.cs
+++ b/VocaDbModel/Domain/Users/AlbumForUser.cs
@@ -6,7 +6,7 @@ namespace VocaDb.Model.Domain.Users;
 
 public class AlbumForUser : IAlbumLink, IEntryWithIntId
 {
-	public const int NotRated = 0;
+	public const double NotRated = 0.0;
 
 	private Album _album;
 	private User _user;
@@ -18,7 +18,7 @@ public class AlbumForUser : IAlbumLink, IEntryWithIntId
 		PurchaseStatus = PurchaseStatus.Owned;
 	}
 
-	public AlbumForUser(User user, Album album, PurchaseStatus status, MediaType mediaType, int rating)
+	public AlbumForUser(User user, Album album, PurchaseStatus status, MediaType mediaType, double rating)
 		: this()
 	{
 		User = user;
@@ -47,7 +47,7 @@ public class AlbumForUser : IAlbumLink, IEntryWithIntId
 	/// <summary>
 	/// Rating score, 0-5 (0 = no rating).
 	/// </summary>
-	public virtual int Rating { get; set; }
+	public virtual double Rating { get; set; }
 
 	public virtual User User
 	{

--- a/VocaDbModel/Domain/Users/User.cs
+++ b/VocaDbModel/Domain/Users/User.cs
@@ -517,7 +517,7 @@ public class User :
 	/// <param name="mediaType">Media type.</param>
 	/// <param name="rating">Rating.</param>
 	/// <returns>Album link. Cannot be null.</returns>
-	public virtual AlbumForUser AddAlbum(Album album, PurchaseStatus status, MediaType mediaType, int rating)
+	public virtual AlbumForUser AddAlbum(Album album, PurchaseStatus status, MediaType mediaType, double rating)
 	{
 		ParamIs.NotNull(() => album);
 

--- a/VocaDbWeb/Controllers/Api/UserApiController.cs
+++ b/VocaDbWeb/Controllers/Api/UserApiController.cs
@@ -668,7 +668,7 @@ public class UserApiController : ApiController
 	/// </remarks>
 	[HttpPost("current/albums/{albumId:int}")]
 	[Authorize]
-	public string PostAlbumStatus(int albumId, PurchaseStatus collectionStatus, MediaType mediaType, int rating)
+	public string PostAlbumStatus(int albumId, PurchaseStatus collectionStatus, MediaType mediaType, double rating)
 	{
 		_queries.UpdateAlbumForUser(_permissionContext.LoggedUserId, albumId, collectionStatus, mediaType, rating);
 		return "OK";

--- a/VocaDbWeb/Controllers/UserController.cs
+++ b/VocaDbWeb/Controllers/UserController.cs
@@ -567,7 +567,7 @@ public class UserController : ControllerBase
 	}
 
 	[HttpPost]
-	public void UpdateAlbumForUser(int albumid, PurchaseStatus collectionStatus, MediaType mediaType, int rating)
+	public void UpdateAlbumForUser(int albumid, PurchaseStatus collectionStatus, MediaType mediaType, double rating)
 	{
 		Data.UpdateAlbumForUser(LoggedUserId, albumid, collectionStatus, mediaType, rating);
 	}

--- a/VocaDbWeb/Models/AlbumModels.cs
+++ b/VocaDbWeb/Models/AlbumModels.cs
@@ -131,7 +131,7 @@ public class AlbumDetails : IEntryImageInformation
 
 	public ArtistForAlbumContract[] Circles { get; set; }
 
-	public int CollectionRating { get; set; }
+	public double CollectionRating { get; set; }
 
 	public int CommentCount { get; set; }
 
@@ -167,7 +167,7 @@ public class AlbumDetails : IEntryImageInformation
 
 	public AlbumReviewContract LatestReview { get; set; }
 
-	public int LatestReviewRatingScore { get; set; }
+	public double LatestReviewRatingScore { get; set; }
 
 	public AlbumContract MergedTo { get; set; }
 

--- a/VocaDbWeb/Scripts/Components/Shared/Partials/Shared/RatingPicker.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/Partials/Shared/RatingPicker.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+
+interface RatingPickerProps {
+	value: number;
+	onChange: (value: number) => void;
+	max?: number;
+}
+
+interface RatingStarProps {
+	fill: number;
+	index: number;
+	onClick: (index: number, event: React.MouseEvent<HTMLSpanElement>) => void;
+	onMouseMove: (
+		index: number,
+		event: React.MouseEvent<HTMLSpanElement>,
+	) => void;
+}
+
+export const RatingStar = ({
+	fill,
+	index,
+	onClick,
+	onMouseMove,
+}: RatingStarProps): React.ReactElement => {
+	return (
+		<span
+			className="rating"
+			style={{
+				position: 'relative',
+				display: 'inline-block',
+				width: 20,
+				height: 20,
+				cursor: 'pointer',
+			}}
+			onClick={(event): void => onClick(index, event)}
+			onMouseMove={(event): void => onMouseMove(index, event)}
+		>
+			<img
+				src="/Content/star_disabled.png"
+				style={{
+					position: 'absolute',
+					left: 0,
+					top: 0,
+					width: '100%',
+				}}
+				alt=""
+			/>
+			<div
+				style={{
+					position: 'absolute',
+					left: 0,
+					top: 0,
+					width: `${fill * 100}%`,
+					height: 20,
+					overflow: 'hidden',
+				}}
+			>
+				<img
+					src="/Content/star.png"
+					style={{
+						width: 20,
+						height: 20,
+						maxWidth: 'none',
+					}}
+					alt="*"
+				/>
+			</div>
+		</span>
+	);
+};
+
+export const RatingPicker = ({
+	value,
+	onChange,
+	max = 5,
+}: RatingPickerProps): React.ReactElement => {
+	const [hoverValue, setHoverValue] = React.useState<number | null>(null);
+	const displayValue = hoverValue ?? value;
+
+	const handleClick = (index: number, event: React.MouseEvent<HTMLSpanElement>): void => {
+		const rect = event.currentTarget.getBoundingClientRect();
+		const x = event.clientX - rect.left;
+		const nextValue = Math.min(max, Math.max(0.5, index + (x < rect.width / 2 ? 0.5 : 1)));
+		onChange(nextValue);
+	};
+
+	const handleMouseMove = (index: number, event: React.MouseEvent<HTMLSpanElement>): void => {
+		const rect = event.currentTarget.getBoundingClientRect();
+		const x = event.clientX - rect.left;
+		const nextValue = Math.min(max, Math.max(0.5, index + (x < rect.width / 2 ? 0.5 : 1)));
+		setHoverValue(nextValue);
+	};
+
+	return (
+		<span onMouseLeave={(): void => setHoverValue(null)} style={{ display: 'inline-flex' }}>
+			{Array.from({ length: max }, (_, index) => {
+				const fill = Math.max(0, Math.min(1, displayValue - index));
+				return (
+					<RatingStar
+						key={index}
+						fill={fill}
+						index={index}
+						onClick={handleClick}
+						onMouseMove={handleMouseMove}
+					/>
+				);
+			})}
+		</span>
+	);
+};
+

--- a/VocaDbWeb/Scripts/Components/Shared/Partials/Shared/Stars.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/Partials/Shared/Stars.tsx
@@ -1,26 +1,82 @@
-import { range } from 'lodash-es';
 import React from 'react';
 
 interface StarsProps {
 	current: number;
 	max: number;
 }
+interface GenerateStarsProps {
+	current: number;
+	max: number;
+	meta: boolean;
+}
+
+interface StarProps {
+	fill: number;
+	current: number;
+	meta: boolean;
+}
+
+function Star({ fill, current, meta }: StarProps) {
+	// fill: 0.0 -> 1.0
+	return (
+		<span
+			style={{
+				position: 'relative',
+				display: 'inline-block',
+				width: 24,
+				height: 24,
+			}}
+			className="rating"
+		>
+			<img
+				src="/Content/star_disabled.png"
+				style={{
+					position: 'absolute',
+					left: 0,
+					top: 0,
+					width: '100%',
+				}}
+				alt={meta ? current.toString() : ''}
+			/>
+
+			<div
+				style={{
+					position: 'absolute',
+					left: 0,
+					top: 0,
+					width: `${fill * 100}%`,
+					height: 24,
+					overflow: 'hidden',
+				}}
+			>
+				<img
+					src="/Content/star.png"
+					style={{
+						width: 24,
+						height: 24,
+						maxWidth: 'none',
+					}}
+					alt={meta ? current.toString() : '*'}
+				/>
+			</div>
+		</span>
+	);
+}
+
+export function GenerateStars({ current, max, meta }: GenerateStarsProps) {
+	return (
+		<>
+			{Array.from({ length: max }, (_, i) => {
+				const fill = Math.max(0, Math.min(1, current - i));
+
+				return <Star key={i} current={current} fill={fill} meta={meta} />;
+			})}
+		</>
+	);
+}
 
 export const Stars = React.memo(
 	({ current, max }: StarsProps): React.ReactElement => {
-		return (
-			<>
-				{range(1, max + 1).map((i) => (
-					<React.Fragment key={i}>
-						{i > 0 && ' '}
-						{current >= i ? (
-							<img src="/Content/star.png" alt="*" />
-						) : (
-							<img src="/Content/star_disabled.png" alt="" />
-						)}
-					</React.Fragment>
-				))}
-			</>
-		);
+		return <GenerateStars current={current} max={max} meta={false} />;
 	},
 );

--- a/VocaDbWeb/Scripts/Components/Shared/Partials/Shared/StarsMeta.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/Partials/Shared/StarsMeta.tsx
@@ -1,4 +1,4 @@
-import { range } from 'lodash-es';
+import { GenerateStars } from '@/Components/Shared/Partials/Shared/Stars';
 import React from 'react';
 
 interface StarsMetaProps {
@@ -8,27 +8,6 @@ interface StarsMetaProps {
 
 export const StarsMeta = React.memo(
 	({ current, max }: StarsMetaProps): React.ReactElement => {
-		return (
-			<>
-				{range(1, max + 1).map((i) => (
-					<React.Fragment key={i}>
-						{i > 0 && ' '}
-						{current >= i ? (
-							<img
-								className="rating"
-								src="/Content/star.png"
-								alt={`${current}`}
-							/>
-						) : (
-							<img
-								className="rating"
-								src="/Content/star_disabled.png"
-								alt={`${current}`}
-							/>
-						)}
-					</React.Fragment>
-				))}
-			</>
-		);
+		return <GenerateStars current={current} max={max} meta={true} />;
 	},
 );

--- a/VocaDbWeb/Scripts/Components/Shared/Partials/Shared/StarsMetaSpan.tsx
+++ b/VocaDbWeb/Scripts/Components/Shared/Partials/Shared/StarsMetaSpan.tsx
@@ -10,7 +10,7 @@ export const StarsMetaSpan = React.memo(
 	({ current, max }: StarsMetaSpanProps): React.ReactElement => {
 		return (
 			<span title={`${Math.round(current * 100) / 100}`}>
-				<StarsMeta current={Math.round(current)} max={max} />
+				<StarsMeta current={current} max={max} />
 			</span>
 		);
 	},

--- a/VocaDbWeb/Scripts/Pages/Album/AlbumReviews.tsx
+++ b/VocaDbWeb/Scripts/Pages/Album/AlbumReviews.tsx
@@ -5,6 +5,7 @@ import { Markdown } from '@/Components/KnockoutExtensions/Markdown';
 import { MomentJsTimeAgo } from '@/Components/KnockoutExtensions/MomentJsTimeAgo';
 import { UserLanguageCultureDropdownList } from '@/Components/Shared/Partials/Knockout/DropdownList';
 import { MarkdownNotice } from '@/Components/Shared/Partials/Shared/MarkdownNotice';
+import { Stars } from '@/Components/Shared/Partials/Shared/Stars';
 import { IconAndLinkKnockout } from '@/Components/Shared/Partials/User/IconAndLinkKnockout';
 import { NameLinkKnockout } from '@/Components/Shared/Partials/User/NameLinkKnockout';
 import { AlbumDetailsForApi } from '@/DataContracts/Album/AlbumDetailsForApi';
@@ -93,23 +94,7 @@ const AlbumReview = observer(
 					</h3>
 
 					{reviewStars > 0 ? (
-						<span>
-							{albumDetailsStore.reviewsStore
-								.ratingStars(reviewStars)
-								.map((ratingStar, index) => (
-									<React.Fragment key={index}>
-										{index > 0 && ' '}
-										{/* eslint-disable-next-line jsx-a11y/alt-text */}
-										<img
-											src={
-												ratingStar.enabled
-													? '/Content/star.png'
-													: '/Content/star_disabled.png'
-											}
-										/>
-									</React.Fragment>
-								))}
-						</span>
+						<Stars current={reviewStars} max={5} />
 					) : (
 						<p style={{ fontStyle: 'italic', marginBottom: 0 }}>
 							{t('ViewRes.Album:Details.ReviewNoRating')}

--- a/VocaDbWeb/Scripts/Pages/Album/Partials/EditCollectionDialog.tsx
+++ b/VocaDbWeb/Scripts/Pages/Album/Partials/EditCollectionDialog.tsx
@@ -7,8 +7,8 @@ import {
 import JQueryUIDialog from '@/JQueryUI/JQueryUIDialog';
 import { urlMapper } from '@/Shared/UrlMapper';
 import { AlbumDetailsStore } from '@/Stores/Album/AlbumDetailsStore';
+import { RatingPicker } from '@/Components/Shared/Partials/Shared/RatingPicker';
 import $ from 'jquery';
-import JqxRating from 'jqwidgets-scripts/jqwidgets-react-tsx/jqxrating';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
@@ -101,15 +101,15 @@ const EditCollectionDialog = observer(
 				</select>
 				<div>
 					{t('ViewRes.Album:Details.MyRating')}
-					<JqxRating
+					<br />
+					<RatingPicker
 						value={albumDetailsStore.editCollectionDialog.collectionRating}
-						onChange={(e: any): void =>
+						onChange={(value): void => {
 							runInAction(() => {
-								albumDetailsStore.editCollectionDialog.collectionRating =
-									e.value;
-							})
-						}
-					/>{' '}
+								albumDetailsStore.editCollectionDialog.collectionRating = value;
+							});
+						}}
+					/>
 					&nbsp;{' '}
 					<SafeAnchor
 						href="#"

--- a/VocaDbWeb/Scripts/Pages/Search/Partials/AlbumSearchList.tsx
+++ b/VocaDbWeb/Scripts/Pages/Search/Partials/AlbumSearchList.tsx
@@ -3,6 +3,7 @@ import { EntryCountBox } from '@/Components/Shared/Partials/EntryCountBox';
 import { ServerSidePaging } from '@/Components/Shared/Partials/Knockout/ServerSidePaging';
 import { AlbumThumbItem } from '@/Components/Shared/Partials/Shared/AlbumThumbItem';
 import { DraftIcon } from '@/Components/Shared/Partials/Shared/DraftIcon';
+import { Stars } from '@/Components/Shared/Partials/Shared/Stars';
 import { AlbumContract } from '@/DataContracts/Album/AlbumContract';
 import { TagBaseContract } from '@/DataContracts/Tag/TagBaseContract';
 import { DateTimeHelper } from '@/Helpers/DateTimeHelper';
@@ -214,21 +215,7 @@ const AlbumSearchList = observer(
 									</td>
 									<td style={{ width: '150px' }}>
 										<span title={`${album.ratingAverage}`}>
-											{albumSearchStore
-												.ratingStars?.(album)
-												.map((ratingStar, index) => (
-													<React.Fragment key={index}>
-														{index > 0 && ' '}
-														{/* eslint-disable-next-line jsx-a11y/alt-text */}
-														<img
-															src={
-																ratingStar.enabled
-																	? '/Content/star.png'
-																	: '/Content/star_disabled.png'
-															}
-														/>
-													</React.Fragment>
-												))}
+											{<Stars current={album.ratingAverage} max={5} />}
 										</span>
 										<br />
 										<span>{album.ratingCount}</span>{' '}

--- a/VocaDbWeb/Scripts/Pages/User/UserAlbums.tsx
+++ b/VocaDbWeb/Scripts/Pages/User/UserAlbums.tsx
@@ -9,6 +9,7 @@ import { ServerSidePaging } from '@/Components/Shared/Partials/Knockout/ServerSi
 import { TagLockingAutoComplete } from '@/Components/Shared/Partials/Knockout/TagLockingAutoComplete';
 import { AlbumAdvancedFilters } from '@/Components/Shared/Partials/Search/AdvancedFilters';
 import { DraftIcon } from '@/Components/Shared/Partials/Shared/DraftIcon';
+import { Stars } from '@/Components/Shared/Partials/Shared/Stars';
 import { MediaType } from '@/DataContracts/User/AlbumForUserForApiContract';
 import { UserDetailsContract } from '@/DataContracts/User/UserDetailsContract';
 import { DateTimeHelper } from '@/Helpers/DateTimeHelper';
@@ -464,21 +465,7 @@ const AlbumCollection = observer(
 										)}
 										<td>
 											<span title={`${albumForUser.rating}`}>
-												{albumCollectionStore
-													.ratingStars(albumForUser.rating)
-													.map((ratingStar, index) => (
-														<React.Fragment key={index}>
-															{index > 0 && ' '}
-															{/* eslint-disable-next-line jsx-a11y/alt-text */}
-															<img
-																src={
-																	ratingStar.enabled
-																		? '/Content/star.png'
-																		: '/Content/star_disabled.png'
-																}
-															/>
-														</React.Fragment>
-													))}
+												<Stars current={albumForUser.rating} max={5} />
 											</span>
 										</td>
 									</tr>


### PR DESCRIPTION
This PR addresses [Issue 2056](https://github.com/VocaDB/vocadb/issues/2056) by allowing users to submit half star ratings. In addition, ratings on pages are fractional as opposed to being whole stars. Below are screenshots taken from a local build of the PR:

Albums list under artist:
<img width="953" height="654" alt="image" src="https://github.com/user-attachments/assets/0eef2dc8-e21c-4b8b-96c7-307648eb804d" />

Album page:
<img width="812" height="684" alt="image" src="https://github.com/user-attachments/assets/041d4633-f2bd-420c-a0c1-fd720046899e" />

Update pop-up:
<img width="979" height="572" alt="image" src="https://github.com/user-attachments/assets/36baf1aa-dea5-4af7-b9a2-66d261fd14f7" />

This PR includes both front-end and back-end changes. The front-end changes are seen above. Notably, the `EditCollectionDialog` component for inputting a rating has a new import: the outdated `import JqxRating from 'jqwidgets-scripts/jqwidgets-react-tsx/jqxrating';` is replaced with a more modern `import Rating from '@mui/material/Rating';` from `material-ui`. For displaying fractional stars, the `<Stars />` component has been tweaked and is now used in places where stars were hard coded (e.g. `AlbumReviews.tsx`). The `<StarsMeta />` and `<StarsMetaSpan />` components were also changed.

Because half-star ratings are allowed, the back-end has been updated to take `rating` and related members in as `double` instead of `int`.  Included in this PR is a migration script to migrate the MSSQL database from `int` to `double`.

This change was tested locally and verified to work.