### PR TITLE
feat: match https://www.nicovideo.jp/shorts/

### DIFF
--- a/Libs/nicovideo-apiclient-dotnet/NicoApiClient/NicoUrlHelper.cs
+++ b/Libs/nicovideo-apiclient-dotnet/NicoApiClient/NicoUrlHelper.cs
@@ -10,6 +10,7 @@ namespace VocaDb.NicoApi {
 		private static readonly RegexLinkMatcher[] matchers = new[] {
 			new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nicovideo.jp/watch/([a-z]{2}\d{2,10})"),
 			new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nicovideo.jp/watch/(\d{6,12})"),
+			new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nicovideo.jp/shorts/(ss\d{2,10})"),
 			new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nico.ms/([a-z]{2}\d{2,10})"),
 			new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nico.ms/(\d{4,12})")
 		};


### PR DESCRIPTION
URL format appears in search results but currently redirects to /watch/, with a red note under the player reading `ショート専用のプレーヤーは後日リリース` (shorts player will be released in the upcoming days). Videos can be already added without issue by manually changing the URL to /watch/.

I have not tested the patch yet locally as it seems trivial ~~and I kind of don't have the energy~~.