### PR TITLE
feat: hide bottom bar when queue is empty

### DIFF
--- a/VocaDbWeb/Scripts/Components/VdbPlayer/VdbPlayer.tsx
+++ b/VocaDbWeb/Scripts/Components/VdbPlayer/VdbPlayer.tsx
@@ -653,6 +653,14 @@ export const VdbPlayer = observer((): React.ReactElement => {
 		);
 	}, [diva, playQueue]);
 
+	React.useEffect(() => {
+		if (playQueue.isEmpty) {
+			vdbPlayer.hideBottomBar();
+		} else {
+			vdbPlayer.showBottomBar();
+		}
+	}, [playQueue.isEmpty, vdbPlayer]);
+
 	return (
 		<>
 			{!playQueue.isEmpty && <MiniPlayer />}


### PR DESCRIPTION
Fixed #1953 
Hook into the existing hide/show functionality of the player bar and toggle it when the empty state of the player is updated.