### PR TITLE
Add support for Niconico Short (alt)

### DIFF
--- a/Libs/nicovideo-apiclient-dotnet/NicoApiClient/NicoUrlHelper.cs
+++ b/Libs/nicovideo-apiclient-dotnet/NicoApiClient/NicoUrlHelper.cs
@@ -8,7 +8,7 @@ namespace VocaDb.NicoApi {
 	public class NicoUrlHelper {
 
 		private static readonly RegexLinkMatcher[] matchers = new[] {
-			new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nicovideo.jp/watch/([a-z]{2}\d{2,10})"),
+			new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nicovideo.jp/(?:watch|shorts)/([a-z]{2}\d{2,10})"),
 			new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nicovideo.jp/watch/(\d{6,12})"),
 			new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nico.ms/([a-z]{2}\d{2,10})"),
 			new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nico.ms/(\d{4,12})")

--- a/VocaDbModel/Service/VideoServices/VideoService.cs
+++ b/VocaDbModel/Service/VideoServices/VideoService.cs
@@ -15,7 +15,7 @@ public class VideoService : IVideoService
 			parser: new NicoParser(),
 			linkMatchers: new[]
 			{
-				new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nicovideo.jp/watch/([a-z]{2}\d{2,10})"),
+				new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nicovideo.jp/(?:watch|shorts)/([a-z]{2}\d{2,10})"),
 				new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nicovideo.jp/watch/(\d{6,12})"),
 				new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nico.ms/([a-z]{2}\d{2,10})"),
 				new RegexLinkMatcher("www.nicovideo.jp/watch/{0}", @"nico.ms/(\d{4,12})")


### PR DESCRIPTION
Alternative to #2168. Continuation of #2082.

This PR adds support for [Niconico Short](https://blog.nicovideo.jp/niconews/272370.html), which is just YouTube Shorts but on NND. The changes are made to be as wide as possible. While it supports short pages (https://www.nicovideo.jp/shorts/ss46530625), it redirects those that are not shorts but viewed on the short pages (https://www.nicovideo.jp/shorts/sm19100559, which redirects to https://www.nicovideo.jp/watch/sm19100559), so it is basically equivalent to cast it wide.

Compared to #2168, this also adds support on nicovideo-apiclient-dotnet.

> [!WARNING] 
>
> Similar to #2082, this change is **untested** as setting up VocaDB is currently a huge chore, but changes are made based on existing codebase.