### PR TITLE
Update links in _Footer.cshtml

### DIFF
--- a/VocaDbWeb/Views/Shared/Partials/_Footer.cshtml
+++ b/VocaDbWeb/Views/Shared/Partials/_Footer.cshtml
@@ -1,11 +1,11 @@
 ﻿@*<span class="about-disclaimer">Background illustration by <a href="https://www.pixiv.net/member_illust.php?mode=medium&illust_id=39733249">火神レオ</a> | <a href="https://code.google.com/p/vocadb/">Other credits</a></span>*@
 <span class="about-disclaimer">
-	<a href="https://piapro.jp/t/nire">@Html.Raw(string.Format(ViewRes._LayoutStrings.BackgroundCredit, "みゆ"))</a>
+	<a href="https://web.archive.org/web/20190410191107/https://piapro.jp/t/nire">@Html.Raw(string.Format(ViewRes._LayoutStrings.BackgroundCredit, "みゆ"))</a>
 	|
 	<a href="https://github.com/VocaDB/vocadb/">@ViewRes._LayoutStrings.OtherCredit</a>
 	|
-	<a href="https://wiki.vocadb.net/wiki/29/license">@ViewRes._LayoutStrings.License</a>
+	<a href="https://wiki.vocadb.net/docs/license">@ViewRes._LayoutStrings.License</a>
 	|
-	<a href="https://wiki.vocadb.net/wiki/50/privacy-and-cookie-policy">@ViewRes._LayoutStrings.PrivacyPolicy</a>
+	<a href="https://wiki.vocadb.net/docs/privacy-and-cookie-policy">@ViewRes._LayoutStrings.PrivacyPolicy</a>
 </span>
 


### PR DESCRIPTION
Pull request to update links in _Footer.cshtml.
Piapro link has been changed to the last available capture of the page on Wayback Machine.
VocaDB Wiki links have been updated so that they no longer redirect.